### PR TITLE
fix: Get error message from failing scan job

### DIFF
--- a/pkg/cmd/commands.go
+++ b/pkg/cmd/commands.go
@@ -50,17 +50,22 @@ func WorkloadFromArgs(namespace string, args []string) (workload kube.Workload, 
 
 const (
 	scanJobTimeoutFlagName = "scan-job-timeout"
+	deleteScanJobFlagName  = "delete-scan-job"
 )
 
 func registerScannerOpts(cmd *cobra.Command) {
 	cmd.Flags().Duration(scanJobTimeoutFlagName, time.Duration(0),
 		"The length of time to wait before giving up on a scan job. Non-zero values should contain a"+
 			" corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout the scan job.")
-
+	cmd.Flags().Bool(deleteScanJobFlagName, true, "If true, delete a scan job either complete or failed")
 }
 
 func getScannerOpts(cmd *cobra.Command) (opts kube.ScannerOpts, err error) {
 	opts.ScanJobTimeout, err = cmd.Flags().GetDuration(scanJobTimeoutFlagName)
+	if err != nil {
+		return
+	}
+	opts.DeleteScanJob, err = cmd.Flags().GetBool(deleteScanJobFlagName)
 	if err != nil {
 		return
 	}

--- a/pkg/find/vulnerabilities/trivy/converter.go
+++ b/pkg/find/vulnerabilities/trivy/converter.go
@@ -42,20 +42,18 @@ func (c *converter) Convert(reader io.Reader) (report starboard.VulnerabilityRep
 
 // TODO Normally I'd use Trivy with the --quiet flag, but in case of errors it does suppress the error message.
 // TODO Therefore, as a workaround I do sanitize the input reader before we start parsing the JSON output.
-func (c *converter) skippingNoisyOutputReader(input io.Reader) (reader io.Reader, err error) {
+func (c *converter) skippingNoisyOutputReader(input io.Reader) (io.Reader, error) {
 	inputAsBytes, err := ioutil.ReadAll(input)
 	if err != nil {
-		return
+		return nil, err
 	}
 	inputAsString := string(inputAsBytes)
 
 	index := strings.Index(inputAsString, "\n[")
 	if index > 0 {
-		reader = strings.NewReader(inputAsString[index:])
-		return
+		return strings.NewReader(inputAsString[index:]), nil
 	}
-	reader = strings.NewReader(inputAsString)
-	return
+	return strings.NewReader(inputAsString), nil
 }
 
 func (c *converter) convert(reports []ScanReport) starboard.VulnerabilityReport {

--- a/pkg/find/vulnerabilities/trivy/converter_test.go
+++ b/pkg/find/vulnerabilities/trivy/converter_test.go
@@ -1,1 +1,120 @@
 package trivy
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	starboard "github.com/aquasecurity/starboard/pkg/apis/aquasecurity/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	sampleReportAsString = `[
+	{
+		"Target": "alpine:3.10.2 (alpine 3.10.2)",
+		"Type": "alpine",
+		"Vulnerabilities": [
+		{
+			"VulnerabilityID": "CVE-2019-1549",
+			"PkgName": "openssl",
+			"InstalledVersion": "1.1.1c-r0",
+			"FixedVersion": "1.1.1d-r0",
+			"Title": "openssl: information disclosure in fork()",
+			"Severity": "MEDIUM",
+			"References": [
+				"https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1549"
+		]
+		},
+		{
+			"VulnerabilityID": "CVE-2019-1547",
+			"PkgName": "openssl",
+			"InstalledVersion": "1.1.1c-r0",
+			"FixedVersion": "1.1.1d-r0",
+			"Title": "openssl: side-channel weak encryption vulnerability",
+			"Severity": "LOW",
+			"References": [
+				"https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1547"
+		]
+		}
+	]
+	}
+]`
+
+	sampleReport = starboard.VulnerabilityReport{
+		Scanner: starboard.Scanner{
+			Name:    "Trivy",
+			Vendor:  "Aqua Security",
+			Version: "0.9.1",
+		},
+		Summary: starboard.VulnerabilitySummary{
+			CriticalCount: 0,
+			MediumCount:   1,
+			LowCount:      1,
+			NoneCount:     0,
+			UnknownCount:  0,
+		},
+		Vulnerabilities: []starboard.VulnerabilityItem{
+			{
+				VulnerabilityID:  "CVE-2019-1549",
+				Resource:         "openssl",
+				InstalledVersion: "1.1.1c-r0",
+				FixedVersion:     "1.1.1d-r0",
+				Severity:         starboard.SeverityMedium,
+				Title:            "openssl: information disclosure in fork()",
+				Links: []string{
+					"https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1549",
+				},
+			},
+			{
+				VulnerabilityID:  "CVE-2019-1547",
+				Resource:         "openssl",
+				InstalledVersion: "1.1.1c-r0",
+				FixedVersion:     "1.1.1d-r0",
+				Severity:         starboard.SeverityLow,
+				Title:            "openssl: side-channel weak encryption vulnerability",
+				Links: []string{
+					"https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1547",
+				},
+			},
+		},
+	}
+)
+
+func TestConverter_Convert(t *testing.T) {
+
+	testCases := []struct {
+		name           string
+		input          string
+		expectedError  error
+		expectedReport starboard.VulnerabilityReport
+	}{
+		{
+			name: "Should convert vulnerability report in JSON format when input is noisy",
+			input: fmt.Sprintf("2020-06-17T23:37:45.320+0200	[34mINFO[0m	Detecting Alpine vulnerabilities...\n%s", sampleReportAsString),
+			expectedError:  nil,
+			expectedReport: sampleReport,
+		},
+		{
+			name:           "Should convert vulnerability report in JSON format when input is quiet",
+			input:          sampleReportAsString,
+			expectedError:  nil,
+			expectedReport: sampleReport,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			report, err := NewConverter().Convert(strings.NewReader(tc.input))
+			switch {
+			case tc.expectedError == nil:
+				require.NoError(t, err)
+				assert.Equal(t, tc.expectedReport, report)
+			default:
+				assert.EqualError(t, err, tc.expectedError.Error())
+			}
+		})
+	}
+
+}

--- a/pkg/find/vulnerabilities/writer.go
+++ b/pkg/find/vulnerabilities/writer.go
@@ -2,10 +2,11 @@ package vulnerabilities
 
 import (
 	"context"
-	sec "github.com/aquasecurity/starboard/pkg/apis/aquasecurity/v1alpha1"
+
+	starboard "github.com/aquasecurity/starboard/pkg/apis/aquasecurity/v1alpha1"
 	"github.com/aquasecurity/starboard/pkg/kube"
 )
 
 type Writer interface {
-	Write(ctx context.Context, workload kube.Workload, reports map[string]sec.VulnerabilityReport) error
+	Write(ctx context.Context, workload kube.Workload, reports map[string]starboard.VulnerabilityReport) error
 }

--- a/pkg/kube/workload.go
+++ b/pkg/kube/workload.go
@@ -96,4 +96,5 @@ func WorkloadKindFromString(s string) (WorkloadKind, error) {
 // ScannerOpts holds configuration of the vulnerability Scanner.
 type ScannerOpts struct {
 	ScanJobTimeout time.Duration
+	DeleteScanJob  bool
 }

--- a/pkg/kubebench/scanner.go
+++ b/pkg/kubebench/scanner.go
@@ -104,7 +104,7 @@ func (s *Scanner) prepareKubeBenchJob() *batch.Job {
 			},
 		},
 		Spec: batch.JobSpec{
-			BackoffLimit:          pointer.Int32Ptr(1),
+			BackoffLimit:          pointer.Int32Ptr(0),
 			Completions:           pointer.Int32Ptr(1),
 			ActiveDeadlineSeconds: s.GetActiveDeadlineSeconds(s.opts.ScanJobTimeout),
 			Template: core.PodTemplateSpec{
@@ -160,11 +160,12 @@ func (s *Scanner) prepareKubeBenchJob() *batch.Job {
 					},
 					Containers: []core.Container{
 						{
-							Name:            kubeBenchContainerName,
-							Image:           kubeBenchContainerImage,
-							ImagePullPolicy: core.PullAlways,
-							Command:         []string{"kube-bench"},
-							Args:            []string{"--json"},
+							Name:                     kubeBenchContainerName,
+							Image:                    kubeBenchContainerImage,
+							ImagePullPolicy:          core.PullAlways,
+							TerminationMessagePolicy: core.TerminationMessageFallbackToLogsOnError,
+							Command:                  []string{"kube-bench"},
+							Args:                     []string{"--json"},
 							VolumeMounts: []core.VolumeMount{
 								{
 									Name:      "var-lib-etcd",


### PR DESCRIPTION
Resolves: #52

This PR leverages container termination messages to get insights into failing scan jobs: https://kubernetes.io/docs/tasks/debug-application-cluster/determine-reason-pod-failure/

For example, if a scan Job for finding vulnerabilities fails, we can see what was the root cause by checking the last state of the underlying Pod created by the scan Job:

```
$ k starboard find vuln deploy/nginx-ko --delete-scan-job=false -v 3
```

```
$ k get pod -n starboard <pod name> -o yaml
```

```yaml
containerStatuses:
  - containerID: docker://ff811ff415b4d8bda909a61a5088b309fb43025eadea7d09fd2acc58ad2e72dd
    image: aquasec/trivy:0.9.1
    imageID: docker-pullable://aquasec/trivy@sha256:5020dac24a63ef4f24452a0c63ebbfe93a5309e40f6353d1ee8221d2184ee954
    lastState: {}
    name: nginx
    ready: false
    restartCount: 0
    started: false
    state:
      terminated:
        containerID: docker://ff811ff415b4d8bda909a61a5088b309fb43025eadea7d09fd2acc58ad2e72dd
        exitCode: 1
        finishedAt: "2020-06-18T08:56:52Z"
        message: "2020-06-18T08:56:52.122Z\t\e[31mFATAL\e[0m\tunable to initialize
          a scanner: unable to initialize a docker scanner: 2 errors occurred:\n\t*
          unable to inspect the image (core.harbor.domain/library/nginx:1.16): Cannot
          connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker
          daemon running?\n\t* Get https://core.harbor.domain/v2/: x509: certificate
          signed by unknown authority\n\n\n"
        reason: Error
        startedAt: "2020-06-18T08:56:52Z"
```

Below is the output of a failing vulnerability scanner:

```
$ starboard find vuln deploy/nginx-ko -v 3
I0618 14:38:05.373881   14181 cert_rotation.go:137] Starting client certificate rotation controller
I0618 14:38:05.375910   14181 scanner.go:55] Getting Pod template for workload: Deployment/nginx-ko
I0618 14:38:05.386222   14181 scanner.go:79] Scanning with options: {ScanJobTimeout:0s DeleteScanJob:true}
I0618 14:38:05.386250   14181 runner.go:79] Running task and waiting forever
I0618 14:38:05.386271   14181 runnable_job.go:47] Creating runnable job: starboard/431fd3e3-ca70-48c7-86cd-ce833ffca706
I0618 14:38:05.392550   14181 reflector.go:207] Starting reflector *v1.Job (30m0s) from pkg/mod/k8s.io/client-go@v0.19.0-alpha.3/tools/cache/reflector.go:156
I0618 14:38:05.392570   14181 reflector.go:243] Listing and watching *v1.Job from pkg/mod/k8s.io/client-go@v0.19.0-alpha.3/tools/cache/reflector.go:156
I0618 14:38:12.066904   14181 runnable_job.go:73] Stopping runnable job on task failure with status: Failed
I0618 14:38:12.066924   14181 runner.go:83] Stopping runner on task completion with error: job failed: BackoffLimitExceeded: Job has reached the specified backoff limit
E0618 14:38:12.073449   14181 scanner.go:251] Container nginx terminated with Error: 2020-06-18T12:38:11.122Z	FATAL	unable to initialize a scanner: unable to initialize a docker scanner: 2 errors occurred:
	* unable to inspect the image (core.harbor.domain/library/nginx:1.16): Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
	* Get https://core.harbor.domain/v2/: x509: certificate signed by unknown authority


error: running scan job: job failed: BackoffLimitExceeded: Job has reached the specified backoff limit

Signed-off-by: Daniel Pacak <pacak.daniel@gmail.com>