### PR TITLE
chore: Update GoReleaser Action config

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -40,5 +40,8 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.txt
-      - name: Build executable binary
-        run: make build
+      - name: Release snapshot
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: v0.138.0
+          args: release --snapshot --skip-publish --rm-dist

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,13 +14,14 @@ jobs:
           go-version: 1.14
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Unshallow # This step is required for the changelog to work correctly
-        run: git fetch --prune --unshallow
+        with:
+          fetch-depth: 0
       - name: Run unit tests
         run: make test
       - name: Release
-        uses: goreleaser/goreleaser-action@v1
+        uses: goreleaser/goreleaser-action@v2
         with:
+          version: v0.138.0
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The latest release of GoReleaser has broken the way we auto generate changes log. Therefore:
- I pinned to GoReleaser v0.138.0
- Updated GitHub Action config

Signed-off-by: Daniel Pacak <pacak.daniel@gmail.com>