### PR TITLE
test(integration): Add scaffold for running integration tests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,12 +34,23 @@ jobs:
       - name: Verify generated code
         run: GOPATH="$(go env GOPATH)" ./hack/verify-codegen.sh
       - name: Run unit tests
-        run: make test
+        run: make unit-tests
       - name: Upload code coverage
         uses: codecov/codecov-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.txt
+      - name: Setup Kubernetes cluster (KIND)
+        uses: engineerd/setup-kind@v0.4.0
+      - name: Test connection to Kubernetes cluster
+        run: |
+          kubectl cluster-info
+      - name: Run integration tests
+        run: |
+          make integration-tests
+          kubectl get crd
+        env:
+          KUBECONFIG: /home/runner/.kube/config
       - name: Release snapshot
         uses: goreleaser/goreleaser-action@v2
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Run unit tests
-        run: make test
+        run: make unit-tests
       - name: Release
         uses: goreleaser/goreleaser-action@v2
         with:

--- a/Makefile
+++ b/Makefile
@@ -6,5 +6,8 @@ build: starboard
 $(BINARY): $(SOURCES)
 	CGO_ENABLED=0 go build -o ./bin/$(BINARY) ./cmd/starboard/main.go
 
-test: $(SOURCES)
+unit-tests: $(SOURCES)
 	go test -v -short -race -timeout 30s -coverprofile=coverage.txt -covermode=atomic ./...
+
+integration-tests: build
+	go test -v ./integration-tests

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,8 @@ go 1.14
 require (
 	github.com/google/go-containerregistry v0.1.1
 	github.com/google/uuid v1.1.1
+	github.com/onsi/ginkgo v1.12.0
+	github.com/onsi/gomega v1.9.0
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.5.1

--- a/hack/tools.go
+++ b/hack/tools.go
@@ -3,4 +3,7 @@
 // This package imports things required by build scripts, to force `go mod` to see them as dependencies.
 package tools
 
-import _ "k8s.io/code-generator"
+import (
+	_ "k8s.io/code-generator"
+	_ "github.com/onsi/ginkgo/ginkgo"
+)

--- a/integration-tests/starboard_integration_suite_test.go
+++ b/integration-tests/starboard_integration_suite_test.go
@@ -4,12 +4,13 @@ import (
 	"os"
 	"testing"
 
-	apiextensions "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1"
-	"k8s.io/client-go/kubernetes"
+	"github.com/onsi/gomega/gexec"
 	"k8s.io/client-go/tools/clientcmd"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	apiextensions "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1"
+	"k8s.io/client-go/kubernetes"
 )
 
 var (
@@ -17,7 +18,15 @@ var (
 	apiextensionsClientset apiextensions.ApiextensionsV1beta1Interface
 )
 
+var (
+	pathToStarboardCLI string
+)
+
 var _ = BeforeSuite(func() {
+	var err error
+	pathToStarboardCLI, err = gexec.Build("github.com/aquasecurity/starboard/cmd/starboard")
+	Expect(err).ToNot(HaveOccurred())
+
 	config, err := clientcmd.BuildConfigFromFlags("", os.Getenv("KUBECONFIG"))
 	Expect(err).ToNot(HaveOccurred())
 
@@ -37,5 +46,5 @@ func TestStarboardCLI(t *testing.T) {
 }
 
 var _ = AfterSuite(func() {
-	// currently do nothing
+	gexec.CleanupBuildArtifacts()
 })

--- a/integration-tests/starboard_integration_suite_test.go
+++ b/integration-tests/starboard_integration_suite_test.go
@@ -1,0 +1,41 @@
+package integration_tests
+
+import (
+	"os"
+	"testing"
+
+	apiextensions "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var (
+	kubernetesClientset    kubernetes.Interface
+	apiextensionsClientset apiextensions.ApiextensionsV1beta1Interface
+)
+
+var _ = BeforeSuite(func() {
+	config, err := clientcmd.BuildConfigFromFlags("", os.Getenv("KUBECONFIG"))
+	Expect(err).ToNot(HaveOccurred())
+
+	kubernetesClientset, err = kubernetes.NewForConfig(config)
+	Expect(err).ToNot(HaveOccurred())
+
+	apiextensionsClientset, err = apiextensions.NewForConfig(config)
+	Expect(err).ToNot(HaveOccurred())
+})
+
+func TestStarboardCLI(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Starboard CLI")
+}
+
+var _ = AfterSuite(func() {
+	// currently do nothing
+})

--- a/integration-tests/starboard_integration_test.go
+++ b/integration-tests/starboard_integration_test.go
@@ -12,10 +12,6 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-const (
-	starboardCmd = "./../bin/starboard"
-)
-
 var _ = Describe("Starboard CLI", func() {
 
 	BeforeEach(func() {
@@ -24,9 +20,9 @@ var _ = Describe("Starboard CLI", func() {
 
 	Describe("Running version command", func() {
 		It("should print the current version of the executable binary", func() {
-			cmd := exec.Command(starboardCmd, []string{"version"}...)
+			cmd := exec.Command(pathToStarboardCLI, []string{"version"}...)
 			output, err := cmd.Output()
-			Expect(err).ShouldNot(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(string(output)).To(Equal("Starboard Version: {Version:dev Commit:none Date:unknown}\n"))
 		})
 
@@ -34,7 +30,7 @@ var _ = Describe("Starboard CLI", func() {
 
 	Describe("Running init command", func() {
 		It("should initialize Starboard", func() {
-			cmd := exec.Command(starboardCmd, []string{"init", "-v", "3"}...)
+			cmd := exec.Command(pathToStarboardCLI, []string{"init", "-v", "3"}...)
 			err := cmd.Run()
 			Expect(err).ToNot(HaveOccurred())
 

--- a/integration-tests/starboard_integration_test.go
+++ b/integration-tests/starboard_integration_test.go
@@ -1,0 +1,70 @@
+package integration_tests
+
+import (
+	"context"
+	"os/exec"
+
+	apiextentions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+const (
+	starboardCmd = "./../bin/starboard"
+)
+
+var _ = Describe("Starboard CLI", func() {
+
+	BeforeEach(func() {
+		// currently do nothing
+	})
+
+	Describe("Running version command", func() {
+		It("should print the current version of the executable binary", func() {
+			cmd := exec.Command(starboardCmd, []string{"version"}...)
+			output, err := cmd.Output()
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(string(output)).To(Equal("Starboard Version: {Version:dev Commit:none Date:unknown}\n"))
+		})
+
+	})
+
+	Describe("Running init command", func() {
+		It("should initialize Starboard", func() {
+			cmd := exec.Command(starboardCmd, []string{"init", "-v", "3"}...)
+			err := cmd.Run()
+			Expect(err).ToNot(HaveOccurred())
+
+			crdsList, err := apiextensionsClientset.CustomResourceDefinitions().List(context.TODO(), meta.ListOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			GetNames := func(crds []apiextentions.CustomResourceDefinition) []string {
+				names := make([]string, len(crds))
+				for i, crd := range crds {
+					names[i] = crd.Name
+				}
+				return names
+			}
+
+			Expect(crdsList.Items).To(WithTransform(GetNames, ContainElements(
+				"ciskubebenchreports.aquasecurity.github.io",
+				"configauditreports.aquasecurity.github.io",
+				"kubehunterreports.aquasecurity.github.io",
+				"vulnerabilities.aquasecurity.github.io",
+			)))
+
+			_, err = kubernetesClientset.CoreV1().Namespaces().Get(context.TODO(), "starboard", meta.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			// TODO Assert other Kubernetes resources that we create in the init command
+		})
+	})
+
+	AfterEach(func() {
+		// currently do nothing
+	})
+
+})

--- a/pkg/polaris/scanner.go
+++ b/pkg/polaris/scanner.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	polarisContainerName = "polaris"
+	polarisContainerName  = "polaris"
 	polarisContainerImage = "quay.io/fairwinds/polaris:1.1.0"
 	polarisConfigVolume   = "config-volume"
 	polarisConfigMap      = "polaris"


### PR DESCRIPTION
In this PR I'd like to introduce:
- https://github.com/onsi/ginkgo - BDD testing framework for Go (good for integration / component / e2e tests; might be overkill for unit tests)
- https://github.com/onsi/gomega - BDD matchers library
- https://github.com/engineerd/setup-kind - GitHub Action to run Kubernetes in Docker cluster

The Gomega has great support for [Asynch Assertions](http://onsi.github.io/gomega/#making-asynchronous-assertions), which is even more relevant for integration testing reconciliation loops, e.g. asserting on desired vs expected / actual state of the world

Signed-off-by: Daniel Pacak <pacak.daniel@gmail.com>