### PR TITLE
refactor: Define interface for async Trivy scanner

### DIFF
--- a/kube/crd/vulnerabilities-crd.yaml
+++ b/kube/crd/vulnerabilities-crd.yaml
@@ -37,15 +37,11 @@ spec:
         report:
           type: object
           required:
-            - generatedAt
             - scanner
             - artifact
             - summary
             - vulnerabilities
           properties:
-            generatedAt:
-              type: string
-              format: date-time
             scanner:
               type: object
               required:

--- a/pkg/find/vulnerabilities/scanner.go
+++ b/pkg/find/vulnerabilities/scanner.go
@@ -5,17 +5,33 @@ import (
 
 	starboard "github.com/aquasecurity/starboard/pkg/apis/aquasecurity/v1alpha1"
 	"github.com/aquasecurity/starboard/pkg/kube"
+	batch "k8s.io/api/batch/v1"
 	core "k8s.io/api/core/v1"
 )
 
-// Scanner defines methods for vulnerability scanner.
+// WorkloadVulnerabilities holds VulnerabilityReports for each container
+// of a Kubernetes workload.
+type WorkloadVulnerabilities map[string]starboard.VulnerabilityReport
+
+// ScannerAsync defines methods for a vulnerability scanner which is
+// run as a Kubernetes Job.
+//
+// PrepareScanJob prepares a Job descriptor for the specified Kubernetes
+// workload with the given Pod descriptor. The returned Job can be sent
+// to the Kubernetes API and scheduled for execution.
+//
+// GetVulnerabilityReportsByScanJob returns WorkloadVulnerabilities from
+// the completed scan Job.
+type ScannerAsync interface {
+	PrepareScanJob(ctx context.Context, workload kube.Object, spec core.PodSpec) (*batch.Job, error)
+	GetVulnerabilityReportsByScanJob(ctx context.Context, job *batch.Job) (WorkloadVulnerabilities, error)
+}
+
+// Scanner defines methods for a synchronous vulnerability scanner.
+// The implementations of the Scanner interface are supposed to block.
 //
 // Scan scans all container images of the specified Kubernetes workload.
 // Returns a map of container names to VulnerabilityReports.
-//
-// ScanByPodSpec scans all container images of the specified Kubernetes workload with the given PodSpec.
-// Returns a map of container names to VulnerabilityReports.
 type Scanner interface {
-	Scan(ctx context.Context, workload kube.Object) (reports map[string]starboard.VulnerabilityReport, err error)
-	ScanByPodSpec(ctx context.Context, workload kube.Object, spec core.PodSpec) (reports map[string]starboard.VulnerabilityReport, err error)
+	Scan(ctx context.Context, workload kube.Object) (WorkloadVulnerabilities, error)
 }


### PR DESCRIPTION
The idea of such interface is to reuse code in starboard security operator for:
- Preparing the descriptor of a Trivy scan job
- Parsing the output logs of the Trivy scan job to convert the JSON output to instances of the vulnerabilities.aquasecurity.github.io resources

**Note:** You can see the client code of such interface in the draft PR https://github.com/aquasecurity/starboard-security-operator/pull/8

Signed-off-by: Daniel Pacak <pacak.daniel@gmail.com>