### PR TITLE
Update polaris to 1.1.0

### DIFF
--- a/pkg/kube/cr_manager.go
+++ b/pkg/kube/cr_manager.go
@@ -2,6 +2,7 @@ package kube
 
 import (
 	"context"
+
 	starboard "github.com/aquasecurity/starboard/pkg/apis/aquasecurity/v1alpha1"
 	core "k8s.io/api/core/v1"
 	rbac "k8s.io/api/rbac/v1"
@@ -16,13 +17,16 @@ import (
 const (
 	polarisConfigYAML = `---
 checks:
+  # reliability
+  multipleReplicasForDeployment: ignore
+  priorityClassNotSet: ignore
   # resources
   cpuRequestsMissing: warning
   cpuLimitsMissing: warning
   memoryRequestsMissing: warning
   memoryLimitsMissing: warning
   # images
-  tagNotSpecified: error
+  tagNotSpecified: danger
   pullPolicyNotAlways: ignore
   # healthChecks
   readinessProbeMissing: warning
@@ -31,114 +35,170 @@ checks:
   hostNetworkSet: warning
   hostPortSet: warning
   # security
-  hostIPCSet: error
-  hostPIDSet: error
-  notReadOnlyRootFileSystem: warning
-  privilegeEscalationAllowed: error
+  hostIPCSet: danger
+  hostPIDSet: danger
+  notReadOnlyRootFilesystem: warning
+  privilegeEscalationAllowed: danger
   runAsRootAllowed: warning
-  runAsPrivileged: error
-  dangerousCapabilities: error
+  runAsPrivileged: danger
+  dangerousCapabilities: danger
   insecureCapabilities: warning
-controllersToScan:
-  - Deployments
-  - StatefulSets
-  - DaemonSets
-  - CronJobs
-  - Jobs
-  - ReplicationControllers
 exemptions:
   - controllerNames:
-      - dns-controller
-      - datadog-datadog
-      - kube-flannel-ds
-      - kube2iam
-      - aws-iam-authenticator
-      - datadog
-      - kube2iam
+    - kube-apiserver
+    - kube-proxy
+    - kube-scheduler
+    - etcd-manager-events
+    - kube-controller-manager
+    - kube-dns
+    - etcd-manager-main
     rules:
-      - hostNetworkSet
+    - hostPortSet
+    - hostNetworkSet
+    - readinessProbeMissing
+    - livenessProbeMissing
+    - cpuRequestsMissing
+    - cpuLimitsMissing
+    - memoryRequestsMissing
+    - memoryLimitsMissing
+    - runAsRootAllowed
+    - runAsPrivileged
+    - notReadOnlyRootFilesystem
+    - hostPIDSet
   - controllerNames:
-      - aws-iam-authenticator
-      - aws-cluster-autoscaler
-      - kube-state-metrics
-      - dns-controller
-      - external-dns
-      - dnsmasq
-      - autoscaler
-      - kubernetes-dashboard
-      - install-cni
-      - kube2iam
+    - kube-flannel-ds
     rules:
-      - readinessProbeMissing
-      - livenessProbeMissing
+    - notReadOnlyRootFilesystem
+    - runAsRootAllowed
+    - notReadOnlyRootFilesystem
+    - readinessProbeMissing
+    - livenessProbeMissing
+    - cpuLimitsMissing
   - controllerNames:
-      - aws-iam-authenticator
-      - nginx-ingress-controller
-      - nginx-ingress-default-backend
-      - aws-cluster-autoscaler
-      - kube-state-metrics
-      - dns-controller
-      - external-dns
-      - kubedns
-      - dnsmasq
-      - autoscaler
-      - tiller
-      - kube2iam
+    - cert-manager
     rules:
-      - runAsRootAllowed
+    - notReadOnlyRootFilesystem
+    - runAsRootAllowed
+    - readinessProbeMissing
+    - livenessProbeMissing
   - controllerNames:
-      - aws-iam-authenticator
-      - nginx-ingress-controller
-      - nginx-ingress-default-backend
-      - aws-cluster-autoscaler
-      - kube-state-metrics
-      - dns-controller
-      - external-dns
-      - kubedns
-      - dnsmasq
-      - autoscaler
-      - tiller
-      - kube2iam
+    - cluster-autoscaler
     rules:
-      - notReadOnlyRootFileSystem
+    - notReadOnlyRootFilesystem
+    - runAsRootAllowed
+    - readinessProbeMissing
   - controllerNames:
-      - cert-manager
-      - dns-controller
-      - kubedns
-      - dnsmasq
-      - autoscaler
-      - insights-agent-goldilocks-vpa-install
+    - vpa
     rules:
-      - cpuRequestsMissing
-      - cpuLimitsMissing
-      - memoryRequestsMissing
-      - memoryLimitsMissing
+    - runAsRootAllowed
+    - readinessProbeMissing
+    - livenessProbeMissing
+    - notReadOnlyRootFilesystem
   - controllerNames:
-      - kube2iam
-      - kube-flannel-ds
+    - datadog
     rules:
-      - runAsPrivileged
+    - runAsRootAllowed
+    - readinessProbeMissing
+    - livenessProbeMissing
+    - notReadOnlyRootFilesystem
   - controllerNames:
-      - kube-hunter
+    - nginx-ingress-controller
     rules:
-      - hostPIDSet
+    - privilegeEscalationAllowed
+    - insecureCapabilities
+    - runAsRootAllowed
   - controllerNames:
-      - polaris
-      - kube-hunter
-      - goldilocks
-      - insights-agent-goldilocks-vpa-install
+    - dns-controller
+    - datadog-datadog
+    - kube-flannel-ds
+    - kube2iam
+    - aws-iam-authenticator
+    - datadog
+    - kube2iam
     rules:
-      - notReadOnlyRootFileSystem
+    - hostNetworkSet
   - controllerNames:
-      - insights-agent-goldilocks-controller
+    - aws-iam-authenticator
+    - aws-cluster-autoscaler
+    - kube-state-metrics
+    - dns-controller
+    - external-dns
+    - dnsmasq
+    - autoscaler
+    - kubernetes-dashboard
+    - install-cni
+    - kube2iam
     rules:
-      - livenessProbeMissing
-      - readinessProbeMissing
+    - readinessProbeMissing
+    - livenessProbeMissing
   - controllerNames:
-      - insights-agent-goldilocks-vpa-install
-      - kube-hunter
+    - aws-iam-authenticator
+    - nginx-ingress-default-backend
+    - aws-cluster-autoscaler
+    - kube-state-metrics
+    - dns-controller
+    - external-dns
+    - kubedns
+    - dnsmasq
+    - autoscaler
+    - tiller
+    - kube2iam
     rules:
-      - runAsRootAllowed
+    - runAsRootAllowed
+  - controllerNames:
+    - aws-iam-authenticator
+    - nginx-ingress-controller
+    - nginx-ingress-default-backend
+    - aws-cluster-autoscaler
+    - kube-state-metrics
+    - dns-controller
+    - external-dns
+    - kubedns
+    - dnsmasq
+    - autoscaler
+    - tiller
+    - kube2iam
+    rules:
+    - notReadOnlyRootFilesystem
+  - controllerNames:
+    - cert-manager
+    - dns-controller
+    - kubedns
+    - dnsmasq
+    - autoscaler
+    - insights-agent-goldilocks-vpa-install
+    - datadog
+    rules:
+    - cpuRequestsMissing
+    - cpuLimitsMissing
+    - memoryRequestsMissing
+    - memoryLimitsMissing
+  - controllerNames:
+    - kube2iam
+    - kube-flannel-ds
+    rules:
+    - runAsPrivileged
+  - controllerNames:
+    - kube-hunter
+    rules:
+    - hostPIDSet
+  - controllerNames:
+    - polaris
+    - kube-hunter
+    - goldilocks
+    - insights-agent-goldilocks-vpa-install
+    rules:
+    - notReadOnlyRootFilesystem
+  - controllerNames:
+    - insights-agent-goldilocks-controller
+    rules:
+    - livenessProbeMissing
+    - readinessProbeMissing
+  - controllerNames:
+    - insights-agent-goldilocks-vpa-install
+    - kube-hunter
+    rules:
+    - runAsRootAllowed
 `
 )
 

--- a/pkg/kube/cr_manager.go
+++ b/pkg/kube/cr_manager.go
@@ -15,8 +15,7 @@ import (
 )
 
 const (
-	polarisConfigYAML = `---
-checks:
+	polarisConfigYAML = `checks:
   # reliability
   multipleReplicasForDeployment: ignore
   priorityClassNotSet: ignore

--- a/pkg/polaris/scanner.go
+++ b/pkg/polaris/scanner.go
@@ -23,7 +23,6 @@ import (
 
 const (
 	polarisContainerName = "polaris"
-	// TODO: The latest semver tagged image 0.6.0 doesn't return audit checks ?!
 	polarisContainerImage = "quay.io/fairwinds/polaris:1.1.0"
 	polarisConfigVolume   = "config-volume"
 	polarisConfigMap      = "polaris"

--- a/pkg/polaris/scanner.go
+++ b/pkg/polaris/scanner.go
@@ -24,7 +24,7 @@ import (
 const (
 	polarisContainerName = "polaris"
 	// TODO: The latest semver tagged image 0.6.0 doesn't return audit checks ?!
-	polarisContainerImage = "quay.io/fairwinds/polaris:cfc0d213cd603793d8e36eecfb0def1579a34997"
+	polarisContainerImage = "quay.io/fairwinds/polaris:1.1.0"
 	polarisConfigVolume   = "config-volume"
 	polarisConfigMap      = "polaris"
 )
@@ -130,7 +130,7 @@ func (s *Scanner) preparePolarisJob() *batch.Job {
 								},
 							},
 							Command: []string{"polaris"},
-							Args:    []string{"audit", "--log-level", "error"},
+							Args:    []string{"audit", "--log-level", "error", "--config", "/examples/config.yaml"},
 						},
 					},
 				},


### PR DESCRIPTION
Up until now we used an old tagged version of Polaris.
This PR updates the polaris release tag to **1.1.0**

Changes made to support the new version:
- Now explicitly specifying the audit config file in the command line.
- Changed the audit config file to an updated default version. (some old values were no longer supported)

related #33 