### PR TITLE
Fix: Command errors now go to stderr

### DIFF
--- a/cmd/starboard/main.go
+++ b/cmd/starboard/main.go
@@ -30,7 +30,7 @@ func main() {
 	version := cmd.VersionInfo{Version: version, Commit: commit, Date: date}
 
 	if err := cmd.NewRootCmd(executable(os.Args), version).Execute(); err != nil {
-		fmt.Printf("error: %v\n", err)
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
The Error handling was done via `fmt.Printf()`
This PR changes this to use the `fmt.Fprintf(os.Stderr)`