### PR TITLE
feat: Define additional printer colums for vulnerabilities resource

### DIFF
--- a/kube/crd/vulnerabilities-crd.yaml
+++ b/kube/crd/vulnerabilities-crd.yaml
@@ -134,3 +134,41 @@ spec:
                     type: array
                     items:
                       type: string
+  additionalPrinterColumns:
+    - JSONPath: .report.artifact.repository
+      type: string
+      name: Repository
+      description: The name of image repository
+    - JSONPath: .report.artifact.tag
+      type: string
+      name: Tag
+      description: The name of image tag
+    - JSONPath: .report.scanner.name
+      type: string
+      name: Scanner
+      description: The name of the vulnerability scanner
+    - JSONPath: .report.summary.criticalCount
+      type: integer
+      name: Critical
+      description: The numer of critical vulnerabilities
+      priority: 1
+    - JSONPath: .report.summary.highCount
+      type: integer
+      name: High
+      description: The number of high vulnerabilities
+      priority: 1
+    - JSONPath: .report.summary.mediumCount
+      type: integer
+      name: Medium
+      description: The number of medium vulnerabilities
+      priority: 1
+    - JSONPath: .report.summary.lowCount
+      type: integer
+      name: Low
+      description: The number of low vulnerabilities
+      priority: 1
+    - JSONPath: .report.summary.unknownCount
+      type: integer
+      name: Unknown
+      description: The number of unknown vulnerabilities
+      priority: 1


### PR DESCRIPTION
If we add additional printer columns to CRD, we can have the following output:

```
$ kubectl get vulnerabilities
NAME                                   REPOSITORY   TAG    SCANNER
ddbb8bfb-040a-42a1-a051-d5aff77a53e7   nginx        1.16   Trivy
```

```
$ kubectl get vulnerabilities -o wide
NAME                                   REPOSITORY   TAG    SCANNER   CRITICAL   HIGH   MEDIUM   LOW   UNKNOWN
ddbb8bfb-040a-42a1-a051-d5aff77a53e7   nginx        1.16   Trivy     0          0      27       92    3
```

Signed-off-by: Daniel Pacak <pacak.daniel@gmail.com>