### PR TITLE
notarization: Add initial stuff for gon integration with goreleaser

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,18 +6,38 @@ on:
 jobs:
   release:
     name: Release
-    runs-on: ubuntu-18.04
+    runs-on: macos-latest
     steps:
       - name: Setup Go
         uses: actions/setup-go@v1
         with:
           go-version: 1.14
+
       - name: Checkout code
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+
       - name: Run unit tests
         run: make unit-tests
+
+      - name: Import Code-Signing Certificates
+        uses: Apple-Actions/import-codesign-certs@v1
+        with:
+          # The certificates in a PKCS12 file encoded as a base64 string created with "openssl base64 -in cert.p12 -out cert-base64.txt"
+          p12-file-base64: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_P12_BASE64 }}
+          # The password used to import the PKCS12 file.
+          p12-password: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_PASSWORD }}
+
+      - name: Install gon
+        run: |
+          brew tap mitchellh/gon
+          brew install mitchellh/gon/gon
+
+      - name: Create gon config file
+        run: |
+          echo ${{ secrets.GON_DMG_CONFIG_BASE64 }} | base64 --decode > gon.json
+
       - name: Release
         uses: goreleaser/goreleaser-action@v2
         with:
@@ -25,5 +45,6 @@ jobs:
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Update new version for plugin 'starboard' in krew-index
         uses: rajatjindal/krew-release-bot@v0.0.38

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ dist/
 coverage.txt
 
 vendor
+
+gon.json

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -15,6 +15,15 @@ builds:
       - windows
     goarch:
       - amd64
+  - id: starboard-macos
+    main: ./cmd/starboard/main.go
+    binary: starboard
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - darwin
+    goarch:
+      - amd64
 archives:
   - name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
     replacements:
@@ -33,3 +42,20 @@ changelog:
       - '^docs'
       - '^test'
       - '^release'
+signs:
+  - signature: "starboard.dmg"
+    id: dmg
+    ids:
+      - starboard-macos # here we filter the macos only build id
+    cmd: gon
+    args:
+      - gon.json
+    artifacts: all
+  - signature: "starboard.zip"
+    id: zip
+    ids:
+      - starboard-macos # here we filter the macos only build id
+    cmd: gon
+    args:
+      - gon.json
+    artifacts: all

--- a/README.md
+++ b/README.md
@@ -224,41 +224,6 @@ To learn more about the available Starboard CLI commands, run `starboard help` o
 $ starboard kube-hunter -h
 ```
 
-## Troubleshooting
-
-### "starboard" cannot be opened because the developer cannot be verified. (macOS)
-
-Since Starboard CLI is not registered with Apple by an identified developer, if you try to run it for the first time
-you might get a warning dialog. This doesn't mean that something is wrong with the release binary, rather macOS can't
-check whether the binary has been modified or broken since it was released.
-
-<p align="center">
-  <img src="docs/images/troubleshooting/developer-not-verified.png">
-</p>
-
-To override your security settings and use the Starboard CLI anyway, follow these steps:
-
-1. In the Finder on your Mac, locate the `starboard` binary.
-2. Control-click the binary icon, then choose Open from the shortcut menu.
-3. Click Open.
-
-   <p align="center">
-     <img src="docs/images/troubleshooting/control-click-open.png">
-   </p>
-
-   The `starboard` is saved as an exception to your security settings, and you can use it just as you can any registered
-   app.
-
-You can also grant an exception for a blocked Starboard release binary by clicking the Allow Anyway button in the
-General pane of Security & Privacy preferences. This button is available for about an hour after you try to run the
-Starboard CLI command.
-
-To open this pane on your Mac, choose Apple menu > System Preferences, click Security & Privacy, then click General.
-
-<p align="center">
-  <img src="docs/images/troubleshooting/developer-not-verified-remediation.png">
-</p>
-
 ## Contributing
 
 At this early stage we would love your feedback on the overall concept of Starboard. Over time we'd love to see


### PR DESCRIPTION
This is some initial work to make gon work with goreleaser and release notarized release artifacts for consumption.

Addresses: https://github.com/aquasecurity/starboard/issues/69


Signed-off-by: Simarpreet Singh <simar@linux.com>