### PR TITLE
feat: Add app.kubernetes.io/managed-by=starboard label to objects created by Starboard

### DIFF
--- a/pkg/apis/aquasecurity/v1alpha1/cis_kube_bench_types.go
+++ b/pkg/apis/aquasecurity/v1alpha1/cis_kube_bench_types.go
@@ -4,6 +4,7 @@ import (
 	"github.com/aquasecurity/starboard/pkg/apis/aquasecurity"
 	extv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 )
 
 const (
@@ -17,6 +18,9 @@ var (
 	CISKubeBenchReportCRD = extv1beta1.CustomResourceDefinition{
 		ObjectMeta: meta.ObjectMeta{
 			Name: CISKubeBenchReportCRName,
+			Labels: labels.Set{
+				"app.kubernetes.io/managed-by": "starboard",
+			},
 		},
 		Spec: extv1beta1.CustomResourceDefinitionSpec{
 			Group: aquasecurity.GroupName,

--- a/pkg/apis/aquasecurity/v1alpha1/config_audit_types.go
+++ b/pkg/apis/aquasecurity/v1alpha1/config_audit_types.go
@@ -4,6 +4,7 @@ import (
 	"github.com/aquasecurity/starboard/pkg/apis/aquasecurity"
 	extv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 )
 
 const (
@@ -17,6 +18,9 @@ var (
 	ConfigAuditReportCRD = extv1beta1.CustomResourceDefinition{
 		ObjectMeta: meta.ObjectMeta{
 			Name: ConfigAuditReportCRName,
+			Labels: labels.Set{
+				"app.kubernetes.io/managed-by": "starboard",
+			},
 		},
 		Spec: extv1beta1.CustomResourceDefinitionSpec{
 			Group: aquasecurity.GroupName,

--- a/pkg/apis/aquasecurity/v1alpha1/kube_hunter_types.go
+++ b/pkg/apis/aquasecurity/v1alpha1/kube_hunter_types.go
@@ -4,6 +4,7 @@ import (
 	"github.com/aquasecurity/starboard/pkg/apis/aquasecurity"
 	extv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 )
 
 const (
@@ -17,6 +18,9 @@ var (
 	KubeHunterReportCRD = extv1beta1.CustomResourceDefinition{
 		ObjectMeta: meta.ObjectMeta{
 			Name: KubeHunterReportCRName,
+			Labels: labels.Set{
+				"app.kubernetes.io/managed-by": "starboard",
+			},
 		},
 		Spec: extv1beta1.CustomResourceDefinitionSpec{
 			Group: aquasecurity.GroupName,

--- a/pkg/apis/aquasecurity/v1alpha1/vulnerability_types.go
+++ b/pkg/apis/aquasecurity/v1alpha1/vulnerability_types.go
@@ -3,6 +3,8 @@ package v1alpha1
 import (
 	"strconv"
 
+	"k8s.io/apimachinery/pkg/labels"
+
 	"k8s.io/utils/pointer"
 
 	"github.com/aquasecurity/starboard/pkg/apis/aquasecurity"
@@ -21,6 +23,9 @@ var (
 	VulnerabilitiesCRD = extv1beta1.CustomResourceDefinition{
 		ObjectMeta: meta.ObjectMeta{
 			Name: VulnerabilitiesCRName,
+			Labels: labels.Set{
+				"app.kubernetes.io/managed-by": "starboard",
+			},
 		},
 		Spec: extv1beta1.CustomResourceDefinitionSpec{
 			Group: aquasecurity.GroupName,

--- a/pkg/kube/cr_manager.go
+++ b/pkg/kube/cr_manager.go
@@ -3,6 +3,8 @@ package kube
 import (
 	"context"
 
+	"k8s.io/apimachinery/pkg/labels"
+
 	starboard "github.com/aquasecurity/starboard/pkg/apis/aquasecurity/v1alpha1"
 	core "k8s.io/api/core/v1"
 	rbac "k8s.io/api/rbac/v1"
@@ -269,6 +271,9 @@ func (m *crManager) initPolaris(ctx context.Context) (err error) {
 	err = m.createOrUpdateClusterRole(ctx, &rbac.ClusterRole{
 		ObjectMeta: meta.ObjectMeta{
 			Name: "starboard-polaris",
+			Labels: labels.Set{
+				"app.kubernetes.io/managed-by": "starboard",
+			},
 		},
 		Rules: []rbac.PolicyRule{
 			{
@@ -323,6 +328,9 @@ func (m *crManager) initPolaris(ctx context.Context) (err error) {
 	err = m.createOrUpdateClusterRoleBinding(ctx, &rbac.ClusterRoleBinding{
 		ObjectMeta: meta.ObjectMeta{
 			Name: "starboard-polaris",
+			Labels: labels.Set{
+				"app.kubernetes.io/managed-by": "starboard",
+			},
 		},
 		RoleRef: rbac.RoleRef{
 			APIGroup: "rbac.authorization.k8s.io",
@@ -386,6 +394,9 @@ func (m *crManager) createNamespaceIfNotFound(ctx context.Context, name string) 
 		_, err = m.clientset.CoreV1().Namespaces().Create(ctx, &core.Namespace{
 			ObjectMeta: meta.ObjectMeta{
 				Name: name,
+				Labels: labels.Set{
+					"app.kubernetes.io/managed-by": "starboard",
+				},
 			},
 		}, meta.CreateOptions{})
 		return
@@ -404,6 +415,9 @@ func (m *crManager) createServiceAccountIfNotFound(ctx context.Context, name str
 		_, err = m.clientset.CoreV1().ServiceAccounts(NamespaceStarboard).Create(ctx, &core.ServiceAccount{
 			ObjectMeta: meta.ObjectMeta{
 				Name: name,
+				Labels: labels.Set{
+					"app.kubernetes.io/managed-by": "starboard",
+				},
 			},
 		}, meta.CreateOptions{})
 		return
@@ -422,6 +436,9 @@ func (m *crManager) createConfigMapIfNotFound(ctx context.Context, name string, 
 		_, err = m.clientset.CoreV1().ConfigMaps(NamespaceStarboard).Create(ctx, &core.ConfigMap{
 			ObjectMeta: meta.ObjectMeta{
 				Name: name,
+				Labels: labels.Set{
+					"app.kubernetes.io/managed-by": "starboard",
+				},
 			},
 			Data: data,
 		}, meta.CreateOptions{})


### PR DESCRIPTION
For troubleshooting and to do a proper cleanup even without running the `starbaord cleanup` subcommand

Signed-off-by: Daniel Pacak <pacak.daniel@gmail.com>