### PR TITLE
feat: Define additional printer columns for vulnerability report

### DIFF
--- a/pkg/apis/aquasecurity/v1alpha1/vulnerability_types.go
+++ b/pkg/apis/aquasecurity/v1alpha1/vulnerability_types.go
@@ -45,6 +45,53 @@ var (
 				Categories: []string{"all"},
 				ShortNames: []string{"vulns", "vuln"},
 			},
+			AdditionalPrinterColumns: []extv1beta1.CustomResourceColumnDefinition{
+				{
+					JSONPath: ".report.artifact.repository",
+					Type:     "string",
+					Name:     "Repository",
+				},
+				{
+					JSONPath: ".report.artifact.tag",
+					Type:     "string",
+					Name:     "Tag",
+				},
+				{
+					JSONPath: ".report.scanner.name",
+					Type:     "string",
+					Name:     "Scanner",
+				},
+				{
+					JSONPath: ".report.summary.criticalCount",
+					Type:     "integer",
+					Name:     "Critical",
+					Priority: 1,
+				},
+				{
+					JSONPath: ".report.summary.highCount",
+					Type:     "integer",
+					Name:     "High",
+					Priority: 1,
+				},
+				{
+					JSONPath: ".report.summary.mediumCount",
+					Type:     "integer",
+					Name:     "Medium",
+					Priority: 1,
+				},
+				{
+					JSONPath: ".report.summary.lowCount",
+					Type:     "integer",
+					Name:     "Low",
+					Priority: 1,
+				},
+				{
+					JSONPath: ".report.summary.unknownCount",
+					Type:     "integer",
+					Name:     "Unknown",
+					Priority: 1,
+				},
+			},
 			Validation: &extv1beta1.CustomResourceValidation{
 				OpenAPIV3Schema: &extv1beta1.JSONSchemaProps{
 					Type: "object",


### PR DESCRIPTION
To have such a nice output:

```
$ kubectl get vulnerabilities
NAME                                   REPOSITORY      TAG    SCANNER
4b53fe18-6808-42c9-a477-d3f3caac73a3   library/nginx   1.16   Trivy
```

```
$ kubectl get vuln -o wide
NAME                                   REPOSITORY      TAG    SCANNER   CRITICAL   HIGH   MEDIUM   LOW   UNKNOWN
4b53fe18-6808-42c9-a477-d3f3caac73a3   library/nginx   1.16   Trivy     0          1      34       93    0
```

Signed-off-by: Daniel Pacak <pacak.daniel@gmail.com>