### PR TITLE
feat: Add summary and printer columns to CISKubeBenchReports

### DIFF
--- a/kube/crd/ciskubebenchreports-crd.yaml
+++ b/kube/crd/ciskubebenchreports-crd.yaml
@@ -18,3 +18,26 @@ spec:
       - all
     shortNames:
       - kubebench
+  additionalPrinterColumns:
+    - JSONPath: .report.scanner.name
+      type: string
+      name: Scanner
+    - JSONPath: .metadata.creationTimestamp
+      type: date
+      name: Age
+    - JSONPath: .report.summary.passCount
+      type: integer
+      name: "Pass
+      priority: 1
+    - JSONPath: .report.summary.infoCount
+      type: integer
+      name: Info
+      priority: 1
+    - JSONPath: .report.summary.warnCount
+      type: integer
+      name: Warn
+      priority: 1
+    - JSONPath: .report.summary.failCount
+      type: integer
+      name: Fail
+      priority: 1

--- a/kube/crd/ciskubebenchreports-crd.yaml
+++ b/kube/crd/ciskubebenchreports-crd.yaml
@@ -27,7 +27,7 @@ spec:
       name: Age
     - JSONPath: .report.summary.passCount
       type: integer
-      name: "Pass
+      name: Pass
       priority: 1
     - JSONPath: .report.summary.infoCount
       type: integer

--- a/kube/crd/vulnerabilities-crd.yaml
+++ b/kube/crd/vulnerabilities-crd.yaml
@@ -147,6 +147,10 @@ spec:
       type: string
       name: Scanner
       description: The name of the vulnerability scanner
+    - JSONPath: .metadata.creationTimestamp
+      type: date
+      name: Age
+      description: The age of Vulnerability
     - JSONPath: .report.summary.criticalCount
       type: integer
       name: Critical

--- a/pkg/apis/aquasecurity/v1alpha1/cis_kube_bench_types.go
+++ b/pkg/apis/aquasecurity/v1alpha1/cis_kube_bench_types.go
@@ -40,6 +40,42 @@ var (
 				Categories: []string{"all"},
 				ShortNames: []string{"kubebench"},
 			},
+			AdditionalPrinterColumns: []extv1beta1.CustomResourceColumnDefinition{
+				{
+					JSONPath: ".report.scanner.name",
+					Type:     "string",
+					Name:     "Scanner",
+				},
+				{
+					JSONPath: ".metadata.creationTimestamp",
+					Type:     "date",
+					Name:     "Age",
+				},
+				{
+					JSONPath: ".report.summary.passCount",
+					Type:     "integer",
+					Name:     "Pass",
+					Priority: 1,
+				},
+				{
+					JSONPath: ".report.summary.infoCount",
+					Type:     "integer",
+					Name:     "Info",
+					Priority: 1,
+				},
+				{
+					JSONPath: ".report.summary.warnCount",
+					Type:     "integer",
+					Name:     "Warn",
+					Priority: 1,
+				},
+				{
+					JSONPath: ".report.summary.failCount",
+					Type:     "integer",
+					Name:     "Fail",
+					Priority: 1,
+				},
+			},
 		},
 	}
 )
@@ -68,7 +104,15 @@ type CISKubeBenchReportList struct {
 
 type CISKubeBenchOutput struct {
 	Scanner  Scanner               `json:"scanner"`
+	Summary  CISKubeBenchSummary   `json:"summary"`
 	Sections []CISKubeBenchSection `json:"sections"`
+}
+
+type CISKubeBenchSummary struct {
+	PassCount int `json:"passCount"`
+	InfoCount int `json:"infoCount"`
+	WarnCount int `json:"warnCount"`
+	FailCount int `json:"failCount"`
 }
 
 type CISKubeBenchSection struct {

--- a/pkg/apis/aquasecurity/v1alpha1/vulnerability_types.go
+++ b/pkg/apis/aquasecurity/v1alpha1/vulnerability_types.go
@@ -62,6 +62,11 @@ var (
 					Name:     "Scanner",
 				},
 				{
+					JSONPath: ".metadata.creationTimestamp",
+					Type:     "date",
+					Name:     "Age",
+				},
+				{
 					JSONPath: ".report.summary.criticalCount",
 					Type:     "integer",
 					Name:     "Critical",

--- a/pkg/kubebench/converter.go
+++ b/pkg/kubebench/converter.go
@@ -30,8 +30,30 @@ func (c *converter) Convert(reader io.Reader) (report starboard.CISKubeBenchOutp
 			Vendor:  "Aqua Security",
 			Version: kubeBenchVersion,
 		},
+		Summary:  c.summary(section),
 		Sections: section,
 	}
 
 	return
+}
+
+func (c *converter) summary(sections []starboard.CISKubeBenchSection) starboard.CISKubeBenchSummary {
+	totalPass := 0
+	totalInfo := 0
+	totalWarn := 0
+	totalFail := 0
+
+	for _, section := range sections {
+		totalPass += section.TotalPass
+		totalInfo += section.TotalInfo
+		totalWarn += section.TotalWarn
+		totalFail += section.TotalFail
+	}
+
+	return starboard.CISKubeBenchSummary{
+		PassCount: totalPass,
+		InfoCount: totalInfo,
+		WarnCount: totalWarn,
+		FailCount: totalFail,
+	}
 }

--- a/pkg/kubebench/testdata/goldenMultiple.json
+++ b/pkg/kubebench/testdata/goldenMultiple.json
@@ -4,6 +4,12 @@
         "vendor": "Aqua Security",
         "version": "0.3.1"
     },
+    "summary": {
+        "passCount": 82,
+        "infoCount": 0,
+        "warnCount": 22,
+        "failCount": 26
+    },
     "sections": [{
         "id": "1",
         "version": "1.5",

--- a/pkg/kubebench/testdata/goldenSingle.json
+++ b/pkg/kubebench/testdata/goldenSingle.json
@@ -4,6 +4,12 @@
         "vendor": "Aqua Security",
         "version": "0.3.1"
     },
+    "summary": {
+        "passCount": 41,
+        "infoCount": 0,
+        "warnCount": 11,
+        "failCount": 13
+    },
     "sections": [{
         "id": "1",
         "version": "1.5",


### PR DESCRIPTION
We could do that for Vulnerability reports. Now we can do the same for CISKubeBenchReports:

```
$ kubectl get vuln -o wide
NAME                                   REPOSITORY      TAG    SCANNER   AGE   CRITICAL   HIGH   MEDIUM   LOW   UNKNOWN
2cec4a5c-ccfa-41ea-856e-87d21650ccc2   library/nginx   1.16   Trivy     11m   0          3      34       94    0
```

```
$ kubectl get kubebench -o wide
NAME                 SCANNER      AGE   PASS   INFO   WARN   FAIL
kind-control-plane   kube-bench   11m   41     0      11     13
```

```
$ kubectl get kubebench -o jsonpath='{.items[*].report.summary.failCount}'
13
```

What's more for frontends, such as Octant or Lens, we don't have to calculate summaries in the plugin code.

Also Octant can display additional columns even if we don't install our plugin:

<img width="1560" alt="octant_built-in_crd_viewer_trivy" src="https://user-images.githubusercontent.com/1322923/92618905-22856980-f2c1-11ea-8042-45faa19217b6.png">

<img width="1560" alt="octant_built-in_crd_viewer_kube_bench" src="https://user-images.githubusercontent.com/1322923/92618924-2913e100-f2c1-11ea-9cca-b969124b716c.png">

Signed-off-by: Daniel Pacak <pacak.daniel@gmail.com>