### PR TITLE
chore: Publish Docker images to DockerHub on release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,6 +18,9 @@ jobs:
           fetch-depth: 0
       - name: Run unit tests
         run: make unit-tests
+      - name: Login to DockerHub Registry
+        run: |
+          echo ${{ secrets.DOCKERHUB_TOKEN }} | docker login --username ${{ secrets.DOCKERHUB_USER }} --password-stdin
       - name: Release
         uses: goreleaser/goreleaser-action@v2
         with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -33,3 +33,17 @@ changelog:
       - '^docs'
       - '^test'
       - '^release'
+dockers:
+  - image_templates:
+      - "docker.io/aquasec/starboard:{{ .Version }}"
+    binaries:
+      - starboard
+    build_flag_templates:
+      - "--label=org.label-schema.schema-version=1.0"
+      - "--label=org.label-schema.name={{ .ProjectName }}"
+      - "--label=org.label-schema.description=Kubernetes-native security toolkit"
+      - "--label=org.label-schema.vendor=Aqua Security"
+      - "--label=org.label-schema.version={{ .Version }}"
+      - "--label=org.label-schema.build-date={{ .Date }}"
+      - "--label=org.label-schema.vcs=https://github.com/aquasecurity/starboard"
+      - "--label=org.label-schema.vcs-ref={{ .FullCommit }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM scratch
+
+COPY starboard /usr/local/bin/starboard
+
+ENTRYPOINT ["starboard"]


### PR DESCRIPTION
Some folks find it useful to have `docker.io/aquasec/starboard` image available from a public registry such as DockerHub, e.g. see #54 

I tested it locally with:

```
$ goreleaser release --snapshot --rm-dist --skip-publish
$ docker run --rm docker.io/aquasec/starboard:924389a5ad7037646eeb7a37ade05494d75a85ba
```

Signed-off-by: Daniel Pacak <pacak.daniel@gmail.com>