### PR TITLE
feat(find vulnerabilities): Configure HTTP proxy for Trivy

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,11 +201,11 @@ To learn more about the available Starboard commands and scanners, such as [kube
 ## Configuration
 
 The `starboard init` command creates the `starboard` ConfigMap in the `starboard` namespace, which contains the default
-configuration parameters. You can change the default config values with `kubectl path` or `kubectl edit` commands.
+configuration parameters. You can change the default config values with `kubectl patch` or `kubectl edit` commands.
 
 For example, by default Trivy displays vulnerabilities with all severity levels (`UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL`).
 However, you can opt in to display only `HIGH` and `CRITICAL` vulnerabilities by patching the `trivy.severity` value
-in the `starbaord` ConfigMap:
+in the `starboard` ConfigMap:
 
 ```
 $ kubectl patch configmap starboard -n starboard \


### PR DESCRIPTION
Some people might run their (dev) clusters behind the proxy.
It is possible to set the HTTP_PROXY environment variable
when using Trivy directly. This commit makes it possible
to use Starboard CLI and pass HTTP proxy config to Trivy by
setting the trivy.httpProxy configuration parameter before
you run the starboard find vulnerabilities command.

$ starboard init
$ kubectl patch configmap starboard -n starboard \
  --type merge \
  -p '{"data": {"trivy.httpProxy":"http://your-proxy:9001"}}'
$ starboard find vulnerabilities deploy/my-deployment

Resolves: #84

Signed-off-by: Daniel Pacak <pacak.daniel@gmail.com>