### PR TITLE
Added Summary Columns for ConfigAudits and KubeHunter Reports

### DIFF
--- a/pkg/apis/aquasecurity/v1alpha1/config_audit_types.go
+++ b/pkg/apis/aquasecurity/v1alpha1/config_audit_types.go
@@ -40,9 +40,43 @@ var (
 				Categories: []string{"all"},
 				ShortNames: []string{"configaudit"},
 			},
+			AdditionalPrinterColumns: []extv1beta1.CustomResourceColumnDefinition{
+				{
+					JSONPath: ".report.scanner.name",
+					Type:     "string",
+					Name:     "Scanner",
+				},
+				{
+					JSONPath: ".metadata.creationTimestamp",
+					Type:     "date",
+					Name:     "Age",
+				},
+				{
+					JSONPath: ".report.summary.dangerCount",
+					Type:     "integer",
+					Name:     "Danger",
+					Priority: 1,
+				},
+				{
+					JSONPath: ".report.summary.warningCount",
+					Type:     "integer",
+					Name:     "Warning",
+					Priority: 1,
+				},
+			},
 		},
 	}
 )
+
+const (
+	ConfigAuditDangerSeverity  = "danger"
+	ConfigAuditWarningSeverity = "warning"
+)
+
+type ConfigAuditSummary struct {
+	DangerCount  int `json:"dangerCount"`
+	WarningCount int `json:"warningCount"`
+}
 
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -70,6 +104,7 @@ type ConfigAuditReportList struct {
 // TODO my-node)
 type ConfigAudit struct {
 	Scanner         Scanner            `json:"scanner"`
+	Summary         ConfigAuditSummary `json:"summary"`
 	PodChecks       []Check            `json:"podChecks"`
 	ContainerChecks map[string][]Check `json:"containerChecks"`
 }

--- a/pkg/apis/aquasecurity/v1alpha1/kube_hunter_types.go
+++ b/pkg/apis/aquasecurity/v1alpha1/kube_hunter_types.go
@@ -40,9 +40,53 @@ var (
 				Categories: []string{"all"},
 				ShortNames: []string{"kubehunter"},
 			},
+			AdditionalPrinterColumns: []extv1beta1.CustomResourceColumnDefinition{
+				{
+					JSONPath: ".report.scanner.name",
+					Type:     "string",
+					Name:     "Scanner",
+				},
+				{
+					JSONPath: ".metadata.creationTimestamp",
+					Type:     "date",
+					Name:     "Age",
+				},
+				{
+					JSONPath: ".report.summary.highCount",
+					Type:     "integer",
+					Name:     "High",
+					Priority: 1,
+				},
+				{
+					JSONPath: ".report.summary.mediumCount",
+					Type:     "integer",
+					Name:     "Medium",
+					Priority: 1,
+				},
+				{
+					JSONPath: ".report.summary.lowCount",
+					Type:     "integer",
+					Name:     "Low",
+					Priority: 1,
+				},
+			},
 		},
 	}
 )
+
+const (
+	KubeHunterSeverityHigh    Severity = "high"
+	KubeHunterSeverityMedium  Severity = "medium"
+	KubeHunterSeverityLow     Severity = "low"
+	KubeHunterSeverityUnknown Severity = "unknown"
+)
+
+type KubeHunterSummary struct {
+	HighCount    int `json:"highCount"`
+	MediumCount  int `json:"mediumCount"`
+	LowCount     int `json:"lowCount"`
+	UnknownCount int `json:"unknownCount"`
+}
 
 // +genclient
 // +genclient:nonNamespaced
@@ -68,16 +112,17 @@ type KubeHunterReportList struct {
 
 type KubeHunterOutput struct {
 	Scanner         Scanner                   `json:"scanner"`
+	Summary         KubeHunterSummary         `json:"summary"`
 	Vulnerabilities []KubeHunterVulnerability `json:"vulnerabilities"`
 }
 
 type KubeHunterVulnerability struct {
-	Location      string `json:"location"`      // e.g. "Local to Pod(kube-hunter-sj7zj)"
-	ID            string `json:"vid"`           // e.g. "KHV050"
-	Category      string `json:"category"`      // e.g. "Access Risk"
-	Severity      string `json:"severity"`      // e.g. "low"
-	Vulnerability string `json:"vulnerability"` // e.g. "Read access to pod's service account token"
-	Description   string `json:"description"`   // e.g. "Accessing the pod service account token gives an attacker the option to use the server API"
-	Evidence      string `json:"evidence"`      // e.g. "eyJhbGciOiJSUzI1NiIMXA1..."
-	Hunter        string `json:"hunter"`        // e.g. "Access Secrets"
+	Location      string   `json:"location"`      // e.g. "Local to Pod(kube-hunter-sj7zj)"
+	ID            string   `json:"vid"`           // e.g. "KHV050"
+	Category      string   `json:"category"`      // e.g. "Access Risk"
+	Severity      Severity `json:"severity"`      // e.g. "low"
+	Vulnerability string   `json:"vulnerability"` // e.g. "Read access to pod's service account token"
+	Description   string   `json:"description"`   // e.g. "Accessing the pod service account token gives an attacker the option to use the server API"
+	Evidence      string   `json:"evidence"`      // e.g. "eyJhbGciOiJSUzI1NiIMXA1..."
+	Hunter        string   `json:"hunter"`        // e.g. "Access Secrets"
 }

--- a/pkg/kubehunter/model.go
+++ b/pkg/kubehunter/model.go
@@ -6,6 +6,23 @@ import (
 	"io"
 )
 
+func toSummary(vulnerabilities []sec.KubeHunterVulnerability) (summary sec.KubeHunterSummary) {
+	for _, v := range vulnerabilities {
+		switch v.Severity {
+		case sec.KubeHunterSeverityHigh:
+			summary.HighCount++
+		case sec.KubeHunterSeverityMedium:
+			summary.MediumCount++
+		case sec.KubeHunterSeverityLow:
+			summary.LowCount++
+		default:
+			summary.UnknownCount++
+		}
+	}
+	return
+}
+
+
 func OutputFrom(reader io.Reader) (report sec.KubeHunterOutput, err error) {
 	report.Scanner = sec.Scanner{
 		Name:    "kube-hunter",
@@ -13,5 +30,10 @@ func OutputFrom(reader io.Reader) (report sec.KubeHunterOutput, err error) {
 		Version: kubeHunterVersion,
 	}
 	err = json.NewDecoder(reader).Decode(&report)
+	if err != nil {
+		return
+	}
+
+	report.Summary = toSummary(report.Vulnerabilities)
 	return
 }

--- a/pkg/polaris/converter.go
+++ b/pkg/polaris/converter.go
@@ -32,6 +32,9 @@ func (c *converter) Convert(reader io.Reader) (reports sec.ConfigAudit, err erro
 
 func (c *converter) toSummary(podChecks []sec.Check, containerChecks map[string][]sec.Check) (summary sec.ConfigAuditSummary) {
 	for _, c := range podChecks {
+		if c.Success {
+			continue
+		}
 		switch c.Severity {
 		case sec.ConfigAuditDangerSeverity:
 			summary.DangerCount++
@@ -41,6 +44,9 @@ func (c *converter) toSummary(podChecks []sec.Check, containerChecks map[string]
 	}
 	for _, checks := range containerChecks {
 		for _, c := range checks {
+			if c.Success {
+				continue
+			}
 			switch c.Severity {
 			case sec.ConfigAuditDangerSeverity:
 				summary.DangerCount++

--- a/pkg/polaris/converter.go
+++ b/pkg/polaris/converter.go
@@ -30,6 +30,28 @@ func (c *converter) Convert(reader io.Reader) (reports sec.ConfigAudit, err erro
 	return
 }
 
+func (c *converter) toSummary(podChecks []sec.Check, containerChecks map[string][]sec.Check) (summary sec.ConfigAuditSummary) {
+	for _, c := range podChecks {
+		switch c.Severity {
+		case sec.ConfigAuditDangerSeverity:
+			summary.DangerCount++
+		case sec.ConfigAuditWarningSeverity:
+			summary.WarningCount++
+		}
+	}
+	for _, checks := range containerChecks {
+		for _, c := range checks {
+			switch c.Severity {
+			case sec.ConfigAuditDangerSeverity:
+				summary.DangerCount++
+			case sec.ConfigAuditWarningSeverity:
+				summary.WarningCount++
+			}
+		}
+	}
+	return
+}
+
 func (c *converter) toConfigAudit(result Result) (report sec.ConfigAudit) {
 	var podChecks []sec.Check
 	containerChecks := make(map[string][]sec.Check)
@@ -65,6 +87,7 @@ func (c *converter) toConfigAudit(result Result) (report sec.ConfigAudit) {
 			Vendor:  "Fairwinds Ops",
 			Version: polarisVersion,
 		},
+		Summary:         c.toSummary(podChecks, containerChecks),
 		PodChecks:       podChecks,
 		ContainerChecks: containerChecks,
 	}


### PR DESCRIPTION
This PR adds additional printer columns to show summary for ConfigAudits and KubeHunter reports. (like already implemented for vulnerabilities reports)

## Examples
### Config Audits 
```bash
$ k get configaudit -o wide                                        
NAME                          SCANNER   AGE     DANGER   WARNING
deployment.nginx-deployment   Polaris   6m31s   0        16
```

### kube-hunter
```bash
$ k get kubehunter -o wide    
NAME      SCANNER       AGE   HIGH   MEDIUM   LOW
cluster   kube-hunter   3s    1      1        1
```

#### As described in the following issues
Closes #149 
Closes #148 