### PR TITLE
feat: adding new config command with get and name-only local flags

### DIFF
--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -1,0 +1,76 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/spf13/cobra"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/kubernetes"
+)
+
+type LocalFlags struct {
+	get string
+	nameOnly bool
+}
+
+var localFlags LocalFlags
+
+func NewConfigCmd(cf *genericclioptions.ConfigFlags, outWriter io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "config",
+		Short: "View the configuration parameters used by starboard scanners",
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			ctx := context.Background()
+			config, err := cf.ToRESTConfig()
+			if err != nil {
+				return
+			}
+			clientset, err := kubernetes.NewForConfig(config)
+			if err != nil {
+				return
+			}
+			starboard := "starboard"	// the configmap name and namespace are both currently "starboard"
+			configMap, err := clientset.CoreV1().ConfigMaps(starboard).Get(ctx, starboard, metav1.GetOptions{})
+			if err != nil {
+				return
+			}
+			_, _ = fmt.Fprintf(outWriter, "%s\n", getFilteredValues(configMap))
+			return
+		},
+	}
+	setLocalFlags(cmd)
+	return cmd
+}
+
+func getFilteredValues(configMap *v1.ConfigMap) string {
+	data := configMap.Data
+	if localFlags.get != "" {
+		return data[localFlags.get]
+	}
+	if localFlags.nameOnly {
+		return convertMapToString(data, true)
+	}
+	return convertMapToString(data, false)
+}
+
+func convertMapToString(mapToConvert map[string]string, nameOnly bool) string {
+	asString := make([]string, 0, len(mapToConvert))
+	for key, val := range mapToConvert {
+		asString = append(asString, key)
+		if !nameOnly {
+			asString = append(asString, val)
+		}
+	}
+	return strings.Join(asString, "\n")
+}
+
+func setLocalFlags(cmd *cobra.Command) {
+	cmd.Flags().BoolVar(&localFlags.nameOnly, "name-only", false, "List parameters by name only")
+	cmd.Flags().StringVar(&localFlags.get, "get", "", "Get configuration parameters for a specified key")
+}
+

--- a/pkg/cmd/config_test.go
+++ b/pkg/cmd/config_test.go
@@ -1,0 +1,1 @@
+package cmd_test

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -34,6 +34,7 @@ func NewRootCmd(version VersionInfo, args []string, outWriter io.Writer, errWrit
 	rootCmd.AddCommand(NewPolarisCmd(cf))
 	rootCmd.AddCommand(NewGetCmd(executable, cf))
 	rootCmd.AddCommand(NewCleanupCmd(cf))
+	rootCmd.AddCommand(NewConfigCmd(cf, outWriter))
 
 	SetGlobalFlags(cf, rootCmd)
 


### PR DESCRIPTION
Added a `starboard config` command, with `--get` and `--name-only` local flags: 

The plain `starboard config` command is equivalent to the kubectl alternative - `kubectl describe configmap --namespace=starboard`
```
$ starboard config
trivy.severity
UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL
polaris.config.yaml
checks:
  # reliability
  multipleReplicasForDeployment: ignore
  priorityClassNotSet: ignore
  ...
```

Adding the `--get` flag returns the values associated with the specified key
```
$ starboard config --get trivy.severity
UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL
```

Including `--name-only` returns just the names (keys) in the config map
```
$ starboard config --name-only
polaris.config.yaml
trivy.severity
```

In the case where a user includes both flags, `--name-only` is ignored.