### PR TITLE
Added instructions to create dev namespace to Getting Started section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 - [Introduction](#introduction)
 - [Installation](#installation)
   - [From the Binary Releases](#from-the-binary-releases)
-    - [kubectl plugin](#kubectl-plugin)
+  - [As a kubectl plugin](#as-a-kubectl-plugin)
   - [From Source (Linux, macOS)](#from-source-linux-macos)
   - [Docker](#docker)
 - [Getting Started](#getting-started)
@@ -25,7 +25,6 @@
 - [Custom Security Resources Definitions](#custom-security-resources-definitions)
 - [Starboard CLI](#starboard-cli)
 - [Troubleshooting](#troubleshooting)
-  - ["starboard" cannot be opened because the developer cannot be verified. (macOS)](#starboard-cannot-be-opened-because-the-developer-cannot-be-verified-macos)
 - [Contributing](#contributing)
 - [License](#license)
 
@@ -58,7 +57,7 @@ binary versions can be manually downloaded and installed.
 
 From there, you should be able to run Starboard CLI commands: `starboard help`
 
-#### kubectl plugin
+### As a kubectl plugin
 
 The Starboard CLI is compatible with [kubectl][kubectl] and is intended as [kubectl plugin][kubectl-plugins],
 but it's perfectly fine to run it as a stand-alone executable. If you rename the `starboard` executable to

--- a/README.md
+++ b/README.md
@@ -12,11 +12,10 @@
 
 ## Table of Contents
 
-- [Table of Contents](#table-of-contents)
 - [Introduction](#introduction)
 - [Installation](#installation)
   - [From the Binary Releases](#from-the-binary-releases)
-  - [As a kubectl plugin](#as-a-kubectl-plugin)
+    - [As a kubectl plugin](#kubectl-plugin)
   - [From Source (Linux, macOS)](#from-source-linux-macos)
   - [Docker](#docker)
 - [Getting Started](#getting-started)
@@ -57,7 +56,7 @@ binary versions can be manually downloaded and installed.
 
 From there, you should be able to run Starboard CLI commands: `starboard help`
 
-### As a kubectl plugin
+#### kubectl plugin
 
 The Starboard CLI is compatible with [kubectl][kubectl] and is intended as [kubectl plugin][kubectl-plugins],
 but it's perfectly fine to run it as a stand-alone executable. If you rename the `starboard` executable to

--- a/README.md
+++ b/README.md
@@ -12,10 +12,11 @@
 
 ## Table of Contents
 
+- [Table of Contents](#table-of-contents)
 - [Introduction](#introduction)
 - [Installation](#installation)
   - [From the Binary Releases](#from-the-binary-releases)
-    - [As a kubectl plugin](#kubectl-plugin)
+    - [kubectl plugin](#kubectl-plugin)
   - [From Source (Linux, macOS)](#from-source-linux-macos)
   - [Docker](#docker)
 - [Getting Started](#getting-started)
@@ -24,6 +25,7 @@
 - [Custom Security Resources Definitions](#custom-security-resources-definitions)
 - [Starboard CLI](#starboard-cli)
 - [Troubleshooting](#troubleshooting)
+  - ["starboard" cannot be opened because the developer cannot be verified. (macOS)](#starboard-cannot-be-opened-because-the-developer-cannot-be-verified-macos)
 - [Contributing](#contributing)
 - [License](#license)
 
@@ -120,8 +122,13 @@ vulnerabilityreports   vulns,vuln    aquasecurity.github.io   true         Vulne
 
 > There's also a `starboard cleanup` subcommand, which can be used to remove all resources created by Starboard.
 
-As an example let's run an old version of `nginx` that we know has vulnerabilities. Create an `nginx` Deployment in the
-`dev` namespace:
+As an example let's run an old version of `nginx` that we know has vulnerabilities. First, let's create a `dev` namespace:
+
+```
+$ kubectl create namespace dev
+```
+
+Create an `nginx` Deployment in the `dev` namespace:
 
 ```
 $ kubectl create deployment nginx --image nginx:1.16 --namespace dev


### PR DESCRIPTION
As I was going through the getting started section for #175 , I thought it would be helpful to have the step to create the `dev` namespace.

I also fixed toc as kubectl plugin is not related to installing from binary release.