### PR TITLE
refactor: Refactor get vulnerabilities command to use client instead of kubectl

### DIFF
--- a/pkg/cmd/get.go
+++ b/pkg/cmd/get.go
@@ -1,16 +1,18 @@
 package cmd
 
 import (
+	"io"
+
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
-func NewGetCmd(executable string, cf *genericclioptions.ConfigFlags) *cobra.Command {
+func NewGetCmd(executable string, cf *genericclioptions.ConfigFlags, outWriter io.Writer) *cobra.Command {
 	getCmd := &cobra.Command{
 		Use:   "get",
 		Short: "Get security reports",
 	}
-	getCmd.AddCommand(NewGetVulnerabilitiesCmd(executable, cf))
+	getCmd.AddCommand(NewGetVulnerabilitiesCmd(executable, cf, outWriter))
 	getCmd.AddCommand(NewGetConfigAuditCmd(cf))
 	getCmd.AddCommand(NewGetReportCmd(cf))
 	getCmd.PersistentFlags().StringP("output", "o", "yaml", "Output format. One of yaml|json")

--- a/pkg/cmd/get_vulnerabilities.go
+++ b/pkg/cmd/get_vulnerabilities.go
@@ -1,15 +1,19 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
-	"os/exec"
+	"io"
 
-	starboard "github.com/aquasecurity/starboard/pkg/apis/aquasecurity/v1alpha1"
+	clientset "github.com/aquasecurity/starboard/pkg/generated/clientset/versioned"
+	"github.com/aquasecurity/starboard/pkg/kube"
 	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
-func NewGetVulnerabilitiesCmd(executable string, cf *genericclioptions.ConfigFlags) *cobra.Command {
+func NewGetVulnerabilitiesCmd(executable string, cf *genericclioptions.ConfigFlags, outWriter io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Aliases: []string{"vulns", "vuln"},
 		Use:     "vulnerabilities (NAME | TYPE/NAME)",
@@ -31,6 +35,17 @@ NAME is the name of a particular Kubernetes workload.
   # Get vulnerabilities for a CronJob with the specified name in JSON output format
   %[1]s get vuln cj/my-job -o json`, executable),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			ctx := context.Background()
+
+			config, err := cf.ToRESTConfig()
+			if err != nil {
+				return
+			}
+			client, err := clientset.NewForConfig(config)
+			if err != nil {
+				return
+			}
+
 			ns, _, err := cf.ToRawKubeConfigLoader().Namespace()
 			if err != nil {
 				return
@@ -44,18 +59,34 @@ NAME is the name of a particular Kubernetes workload.
 				return
 			}
 
-			kubectlCmd := exec.Command("kubectl",
-				"get",
-				starboard.VulnerabilityReportsCRName,
-				fmt.Sprintf("-l=starboard.resource.kind=%s,starboard.resource.name=%s", workload.Kind, workload.Name),
-				fmt.Sprintf("--namespace=%s", workload.Namespace),
-				fmt.Sprintf("--output=%s", cmd.Flag("output").Value.String()))
-			stdoutStderr, err := kubectlCmd.CombinedOutput()
+			list, err := client.AquasecurityV1alpha1().
+				VulnerabilityReports(workload.Namespace).
+				List(ctx, metav1.ListOptions{
+					LabelSelector: labels.Set{
+						kube.LabelResourceKind:      string(workload.Kind),
+						kube.LabelResourceName:      workload.Name,
+						kube.LabelResourceNamespace: workload.Namespace,
+					}.
+						String(),
+				})
 			if err != nil {
-				return
+				return fmt.Errorf("list vulnerability reports: %v", err)
 			}
-			fmt.Printf("%s", stdoutStderr)
-			return
+
+			format := cmd.Flag("output").Value.String()
+			printer, err := genericclioptions.NewPrintFlags("").
+				WithTypeSetter(GetScheme()).
+				WithDefaultOutput(format).
+				ToPrinter()
+			if err != nil {
+				return fmt.Errorf("create printer: %v", err)
+			}
+
+			if err := printer.PrintObj(list, outWriter); err != nil {
+				return fmt.Errorf("print vulnerability reports: %v", err)
+			}
+
+			return nil
 		},
 	}
 

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -6,11 +6,10 @@ import (
 	"path/filepath"
 	"strings"
 
+	starboardv1alpha1 "github.com/aquasecurity/starboard/pkg/apis/aquasecurity/v1alpha1"
 	"github.com/aquasecurity/starboard/pkg/starboard"
-
-	"github.com/spf13/pflag"
-
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
@@ -34,7 +33,7 @@ func NewRootCmd(version starboard.BuildInfo, args []string, outWriter io.Writer,
 	rootCmd.AddCommand(NewKubeBenchCmd(cf))
 	rootCmd.AddCommand(NewKubeHunterCmd(cf))
 	rootCmd.AddCommand(NewPolarisCmd(cf))
-	rootCmd.AddCommand(NewGetCmd(executable, cf))
+	rootCmd.AddCommand(NewGetCmd(executable, cf, outWriter))
 	rootCmd.AddCommand(NewCleanupCmd(cf))
 	rootCmd.AddCommand(NewConfigCmd(cf, outWriter))
 
@@ -72,4 +71,8 @@ func initFlags() {
 			pflag.Lookup(f.Name).Hidden = true
 		}
 	})
+}
+
+func init() {
+	_ = starboardv1alpha1.AddToScheme(GetScheme())
 }


### PR DESCRIPTION
Fixes https://github.com/aquasecurity/starboard/issues/142