### PR TITLE
Chore: bump up alpine to 3.12

### DIFF
--- a/Dockerfile.starboard-scanner-aqua
+++ b/Dockerfile.starboard-scanner-aqua
@@ -1,4 +1,4 @@
-FROM alpine:3.9
+FROM alpine:3.12
 
 RUN echo "@edge http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories
 


### PR DESCRIPTION
Alpine 3.9 is becoming EOL as of 1st of November 2021. Alpine 3.12 is the latest release of Alpine