### PR TITLE
feat: Add dry-run option to init command

### DIFF
--- a/itest/suite_test.go
+++ b/itest/suite_test.go
@@ -17,6 +17,8 @@ import (
 	apiextensions "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1"
 	"k8s.io/client-go/kubernetes"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	rbacv1 "k8s.io/client-go/kubernetes/typed/rbac/v1"
+
 	"k8s.io/client-go/tools/clientcmd"
 )
 
@@ -36,6 +38,10 @@ var (
 var (
 	namespaces                corev1.NamespaceInterface
 	customResourceDefinitions apiextensions.CustomResourceDefinitionInterface
+	configmaps                corev1.ConfigMapInterface
+	serviceAccounts           corev1.ServiceAccountInterface
+	clusterRoles              rbacv1.ClusterRoleInterface
+	clusterRoleBindings       rbacv1.ClusterRoleBindingInterface
 )
 
 // TestStarboardCLI is a spec that describes the behavior of Starboard CLI.
@@ -70,6 +76,10 @@ var _ = BeforeSuite(func() {
 
 	namespaces = kubernetesClientset.CoreV1().Namespaces()
 	customResourceDefinitions = apiextensionsClientset.CustomResourceDefinitions()
+	configmaps = kubernetesClientset.CoreV1().ConfigMaps(namespaceItest)
+	serviceAccounts = kubernetesClientset.CoreV1().ServiceAccounts(namespaceItest)
+	clusterRoles = kubernetesClientset.RbacV1().ClusterRoles()
+	clusterRoleBindings = kubernetesClientset.RbacV1().ClusterRoleBindings()
 
 	err = createNamespace()
 	Expect(err).ToNot(HaveOccurred())

--- a/pkg/cmd/cleanup.go
+++ b/pkg/cmd/cleanup.go
@@ -28,7 +28,7 @@ func NewCleanupCmd(cf *genericclioptions.ConfigFlags) *cobra.Command {
 			if err != nil {
 				return
 			}
-			err = kube.NewCRManager(clientset, clientsetext).Cleanup(ctx)
+			err = kube.NewCRManager(clientset, clientsetext, &kube.InitOptions{}, nil).Cleanup(ctx)
 			return
 		},
 	}

--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -2,15 +2,16 @@ package cmd
 
 import (
 	"context"
-
-	"github.com/aquasecurity/starboard/pkg/kube"
+	starboard "github.com/aquasecurity/starboard/pkg/kube"
 	"github.com/spf13/cobra"
+	"io"
 	extensionsapi "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/kubernetes"
 )
 
-func NewInitCmd(cf *genericclioptions.ConfigFlags) *cobra.Command {
+func NewInitCmd(cf *genericclioptions.ConfigFlags, outWriter io.Writer) *cobra.Command {
+	options := &starboard.InitOptions{}
 	cmd := &cobra.Command{
 		Use:   "init",
 		Short: "Create custom resource definitions used by starboard",
@@ -43,9 +44,12 @@ These resources can be removed from the cluster using the "cleanup" command.
 			if err != nil {
 				return
 			}
-			err = kube.NewCRManager(clientset, clientsetext).Init(ctx)
+
+			err = starboard.NewCRManager(clientset, clientsetext, options, outWriter).Init(ctx)
 			return
 		},
 	}
+	cmd.Flags().BoolVar(&options.DryRun, "dry-run", false, "Only print the object that would be sent, without sending it.")
+
 	return cmd
 }

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -29,7 +29,7 @@ func NewRootCmd(version starboard.BuildInfo, args []string, outWriter io.Writer,
 	executable := executable(args)
 
 	rootCmd.AddCommand(NewVersionCmd(version, outWriter))
-	rootCmd.AddCommand(NewInitCmd(cf))
+	rootCmd.AddCommand(NewInitCmd(cf, outWriter))
 	rootCmd.AddCommand(NewFindCmd(executable, cf))
 	rootCmd.AddCommand(NewKubeBenchCmd(cf))
 	rootCmd.AddCommand(NewKubeHunterCmd(cf))

--- a/pkg/kube/starboard.go
+++ b/pkg/kube/starboard.go
@@ -27,3 +27,8 @@ type ScannerOpts struct {
 	ScanJobTimeout time.Duration
 	DeleteScanJob  bool
 }
+
+// InitOptions stores the commandline options for 'init' sub command
+type InitOptions struct {
+	DryRun bool
+}


### PR DESCRIPTION
Added an additional flag to the init command to allow it run as a
dry-run. Where ever possible, it follows the same convention as kubectl.

Example:

$ starboard init --dry-run

crd/vulnerabilityreports.aquasecurity.github.io created (dry run)
crd/ciskubebenchreports.aquasecurity.github.io created (dry run)
crd/kubehunterreports.aquasecurity.github.io created (dry run)
crd/configauditreports.aquasecurity.github.io created (dry run)
namespace/starboard created (dry run)
configmap/starboard created (dry run)
serviceaccount/starboard created (dry run)
clusterrole.rbac.authorization.k8s.io/starboard created (dry run)
clusterrolebinding.rbac.authorization.k8s.io/starboard created (dry run)

The expection is that when running this command no resources should be
created in the cluster. Integrations tests have been added to verify this.

This is part of #55 but does not resolve it completely.

Signed-off-by: Shaun McLernon <shaun@codesome.tech>