### PR TITLE
docs: Fix typo in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,7 +112,7 @@ $ make unit-tests
 To open the test coverage report in your web browser, run:
 
 ```
-$ go tool cover -html=coverage.txt`.
+$ go tool cover -html=coverage.txt
 ```
 
 ### Run Integration Tests


### PR DESCRIPTION
There is no issue ticket for this. Whilst reviewing the CONTRIBUTING
docs, I spotted a very minor typo on the unit tests section.

Signed-off-by: Shaun McLernon <shaun@codesome.tech>