### PR TITLE
refactor: Refactor get configaudit command to use client instead of kubectl

### DIFF
--- a/pkg/cmd/get.go
+++ b/pkg/cmd/get.go
@@ -13,7 +13,7 @@ func NewGetCmd(executable string, cf *genericclioptions.ConfigFlags, outWriter i
 		Short: "Get security reports",
 	}
 	getCmd.AddCommand(NewGetVulnerabilitiesCmd(executable, cf, outWriter))
-	getCmd.AddCommand(NewGetConfigAuditCmd(cf))
+	getCmd.AddCommand(NewGetConfigAuditCmd(executable, cf, outWriter))
 	getCmd.AddCommand(NewGetReportCmd(cf))
 	getCmd.PersistentFlags().StringP("output", "o", "yaml", "Output format. One of yaml|json")
 


### PR DESCRIPTION
The purpose is to solve the problem described in #142 but for configaudit.

Technically, this is similar to #193 