### PR TITLE
feat(config): Add starboard secret to store sensitive config params

### DIFF
--- a/itest/starboard/starboard_cli_test.go
+++ b/itest/starboard/starboard_cli_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aquasecurity/starboard/pkg/apis/aquasecurity/v1alpha1"
 	"github.com/aquasecurity/starboard/pkg/cmd"
 	"github.com/aquasecurity/starboard/pkg/kube"
+	"github.com/aquasecurity/starboard/pkg/starboard"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gbytes"
@@ -143,10 +144,22 @@ var _ = Describe("Starboard CLI", func() {
 				}),
 			}))
 
-			_, err = namespaces.Get(context.TODO(), "starboard", metav1.GetOptions{})
+			_, err = namespaces.Get(context.TODO(), starboard.NamespaceName, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
-			// TODO Assert other Kubernetes resources that we create in the init command
+			cm, err := kubernetesClientset.CoreV1().ConfigMaps(starboard.NamespaceName).
+				Get(context.TODO(), starboard.ConfigMapName, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cm.Data).To(BeEquivalentTo(starboard.GetDefaultConfig()))
+
+			secret, err := kubernetesClientset.CoreV1().Secrets(starboard.NamespaceName).
+				Get(context.TODO(), starboard.SecretName, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(secret.Data).To(Equal(map[string][]byte(nil)))
+
+			_, err = kubernetesClientset.CoreV1().ServiceAccounts(starboard.NamespaceName).
+				Get(context.TODO(), starboard.ServiceAccountName, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
 		})
 	})
 

--- a/pkg/cmd/cleanup.go
+++ b/pkg/cmd/cleanup.go
@@ -3,9 +3,8 @@ package cmd
 import (
 	"context"
 
-	"github.com/aquasecurity/starboard/pkg/starboard"
-
 	"github.com/aquasecurity/starboard/pkg/kube"
+	"github.com/aquasecurity/starboard/pkg/starboard"
 	"github.com/spf13/cobra"
 	extapi "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
@@ -15,9 +14,8 @@ import (
 func NewCleanupCmd(cf *genericclioptions.ConfigFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "cleanup",
-		Short: "Delete custom resource definitions created by starboard",
+		Short: "Delete Kubernetes resources created by Starboard",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := context.Background()
 			config, err := cf.ToRESTConfig()
 			if err != nil {
 				return err
@@ -30,8 +28,9 @@ func NewCleanupCmd(cf *genericclioptions.ConfigFlags) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return kube.NewCRManager(starboard.NewConfigManager(clientset, starboard.NamespaceName), clientset, clientsetext).
-				Cleanup(ctx)
+			configManager := starboard.NewConfigManager(clientset, starboard.NamespaceName)
+			return kube.NewCRManager(clientset, clientsetext, configManager).
+				Cleanup(context.TODO())
 		},
 	}
 	return cmd

--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/aquasecurity/starboard/pkg/starboard"
-
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/kubernetes"
@@ -22,27 +21,27 @@ func NewConfigCmd(cf *genericclioptions.ConfigFlags, outWriter io.Writer) *cobra
 	var localFlags LocalFlags
 	cmd := &cobra.Command{
 		Use:   "config",
-		Short: "View the configuration parameters used by starboard scanners",
-		RunE: func(cmd *cobra.Command, args []string) (err error) {
+		Short: "View the configuration parameters used by Starboard scanners",
+		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 			kubernetesConfig, err := cf.ToRESTConfig()
 			if err != nil {
-				return
+				return err
 			}
 			clientset, err := kubernetes.NewForConfig(kubernetesConfig)
 			if err != nil {
-				return
+				return err
 			}
 			config, err := starboard.NewConfigManager(clientset, starboard.NamespaceName).Read(ctx)
 			if err != nil {
-				return
+				return err
 			}
 			filteredValues, err := getFilteredValues(config, &localFlags)
 			if err != nil {
-				return
+				return err
 			}
 			_, _ = fmt.Fprintf(outWriter, "%s\n", filteredValues)
-			return
+			return nil
 		},
 	}
 	setLocalFlags(cmd, &localFlags)

--- a/pkg/starboard/constants.go
+++ b/pkg/starboard/constants.go
@@ -2,13 +2,18 @@ package starboard
 
 const (
 	// NamespaceName the name of the namespace in which Starboard stores its
-	// configuration and runs scan Jobs.
+	// configuration and where it runs scan jobs.
 	NamespaceName = "starboard"
 
-	// ServiceAccountName the name of the ServiceAccount used to run scan Jobs.
+	// ServiceAccountName the name of the service account used to provide
+	// identity for scan jobs run by Starboard.
 	ServiceAccountName = "starboard"
 
-	// ConfigMapName the name of the ConfigMap that stored configuration of
-	// Starboard and the underlying scanners.
+	// ConfigMapName the name of the ConfigMap where Starboard stores its
+	// configuration.
 	ConfigMapName = "starboard"
+
+	// SecretName the name of the secret where Starboard stores is sensitive
+	// configuration.
+	SecretName = "starboard"
 )

--- a/pkg/trivy/scanner.go
+++ b/pkg/trivy/scanner.go
@@ -39,11 +39,11 @@ type scanner struct {
 // NewScanner constructs a new Plugin, which is using an official
 // Trivy container image to scan Kubernetes workloads.
 //
-// This Plugin supports both trivy.Standalone and trivy.ClientServer
+// This Plugin supports both starboard.Standalone and starboard.ClientServer
 // client modes depending on the current starboard.TrivyConfig.
 //
-// The trivy.ClientServer more is usually more performant, however it requires
-// a Trivy server to be hosted and accessible at the configurable URL.
+// The starboard.ClientServer more is usually more performant, however it
+// requires a Trivy server to be hosted and accessible at the configurable URL.
 func NewScannerPlugin(idGenerator ext.IDGenerator, config starboard.TrivyConfig) vulnerabilityreport.Plugin {
 	return &scanner{
 		idGenerator: idGenerator,
@@ -121,9 +121,9 @@ func (s *scanner) getPodSpecForStandaloneMode(spec corev1.PodSpec, credentials m
 			{
 				Name: "GITHUB_TOKEN",
 				ValueFrom: &corev1.EnvVarSource{
-					ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+					SecretKeyRef: &corev1.SecretKeySelector{
 						LocalObjectReference: corev1.LocalObjectReference{
-							Name: starboard.ConfigMapName,
+							Name: starboard.SecretName,
 						},
 						Key:      "trivy.githubToken",
 						Optional: pointer.BoolPtr(true),


### PR DESCRIPTION
The init command creates the starboard ConfigMap in the starboard namespace.
This is not suitable for setting sensitive params such as tokens or passwords.

Signed-off-by: Daniel Pacak <pacak.daniel@gmail.com>