### PR TITLE
chore(make): Add target to run MkDocs server and preview docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,9 @@ STARBOARD_CLI_IMAGE := aquasec/starboard:$(IMAGE_TAG)
 STARBOARD_OPERATOR_IMAGE := aquasec/starboard-operator:$(IMAGE_TAG)
 STARBOARD_SCANNER_AQUA_IMAGE := aquasec/starboard-scanner-aqua:$(IMAGE_TAG)
 
+MKDOCS_IMAGE := squidfunk/mkdocs-material:6.1.7
+MKDOCS_PORT := 8000
+
 .PHONY: all
 all: build
 
@@ -115,3 +118,8 @@ docker-build-starboard-operator: build-starboard-operator
 ## Builds Docker image for Aqua scanner
 docker-build-starboard-scanner-aqua: build-starboard-scanner-aqua
 	docker build --no-cache -t $(STARBOARD_SCANNER_AQUA_IMAGE) -f build/scanner-aqua/Dockerfile bin
+
+.PHONY: mkdocs-serve
+## Runs MkDocs development server to preview the documentation page
+mkdocs-serve:
+	docker run --name mkdocs-serve --rm -v $(PWD):/docs -p $(MKDOCS_PORT):8000 $(MKDOCS_IMAGE)


### PR DESCRIPTION
Use docker to preview MkDocs site without installing it on your laptop:

```
$ make mkdocs-serve && open http://localhost:8080
```

```
$ make mkdocs-serve MKDOCS_PORT=9090 && open http://localhost:9090
```

Signed-off-by: Daniel Pacak <pacak.daniel@gmail.com>