### PR TITLE
Fix polaris example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ also know that in Kubernetes the defaults are usually the least secure.
 Run the scanner to audit the configuration using [Polaris][polaris]:
 
 ```
-$ starboard polaris deployment/nginx --namespace dev
+$ starboard scan configauditreports deployment/nginx --namespace dev
 ```
 
 Retrieve the configuration audit report:


### PR DESCRIPTION
The README contained an outdated starboard command in its polaris example.

Fixes #293

Signed-off-by: Christian Zunker <christian.zunker@codecentric.cloud>