### PR TITLE
docs(olm): Update docs how to install operator from OperatorHub.io

### DIFF
--- a/docs/cli/installation/docker.md
+++ b/docs/cli/installation/docker.md
@@ -1,7 +1,7 @@
-We also release the Docker image `aquasec/starboard:$VERSION` to run Starboard as a Docker container or to
-manually schedule Kubernetes scan Jobs in your cluster.
+We also release Docker images `aquasec/starboard:$VERSION` and `public.ecr.aws/aquasecurity/starboard:$VERSION` to run
+Starboard as a Docker container or to manually schedule Kubernetes scan Jobs in your cluster.
 
 ```
-docker container run --rm aquasec/starboard:0.4.0 version
-Starboard Version: {Version:0.4.0 Commit:dd8e49701c1817ea174061c8731fe5bdbfb73d93 Date:2020-09-21T09:36:59Z}
+docker container run --rm public.ecr.aws/aquasecurity/starboard:0.8.0 version
+Starboard Version: {Version:0.8.0 Commit:10a7cc45d646cefcf09447f9b26d5624551dd495 Date:2021-01-07T17:58:22Z}
 ```

--- a/docs/operator/installation/helm.md
+++ b/docs/operator/installation/helm.md
@@ -16,9 +16,11 @@ configure it to watch the `default` namespaces:
 
         kubectl create namespace starboard-operator
 
-3. (Optional) Configure the operator by creating the `starboard` ConfigMap and
-   the `starboard` secret in the `starboard-operator` namespace. If you skip
-   this step, the operator will ensure [configuration objects](./../../configuration.md)
+3. (Optional) Configure Starboard by creating the `starboard` ConfigMap and the `starboard` secret in
+   the `starboard-operator` namespace. For example, you can use Trivy
+   in [ClientServer](./../../integrations/vulnerability-scanners/trivy.md#clientserver) mode or
+   [Aqua Enterprise](./../../integrations/vulnerability-scanners/aqua-enterprise.md) as an active vulnerability scanner.
+   If you skip this step, the operator will ensure [configuration objects](./../../configuration.md)
    on startup with the default settings.
 
         kubectl apply -f https://raw.githubusercontent.com/aquasecurity/starboard/main/deploy/static/05-starboard-operator.config.yaml
@@ -33,34 +35,25 @@ configure it to watch the `default` namespaces:
           -n starboard-operator \
           --set="targetNamespaces=default"
 
-Check that the `starboard-operator` Helm release is created in the `starboard-operator`
-namespace:
+5. Check that the `starboard-operator` Helm release is created in the `starboard-operator`
+   namespace:
 
-```
-helm list -n starboard-operator
-```
+        helm list -n starboard-operator
+        NAME              	NAMESPACE         	REVISION	UPDATED                             	STATUS  	CHART                   	APP VERSION
+        starboard-operator	starboard-operator	1       	2020-12-09 16:15:51.070673 +0100 CET	deployed	starboard-operator-0.2.1	0.7.1
+   To confirm that the operator is running, check the number of replicas created by
+   the `starboard-operator` Deployment in the `starboard-operator` namespace:
 
-```text
-NAME              	NAMESPACE         	REVISION	UPDATED                             	STATUS  	CHART                   	APP VERSION
-starboard-operator	starboard-operator	1       	2020-12-09 16:15:51.070673 +0100 CET	deployed	starboard-operator-0.2.1	0.7.1
-```
+        kubectl get deployment -n starboard-operator
+        NAME                 READY   UP-TO-DATE   AVAILABLE   AGE
+        starboard-operator   1/1     1            1           11m
+   If for some reason it's not ready yet, check the logs of the Deployment for
+   errors:
 
-To confirm that the operator is running, check the number of replicas created by
-the `starboard-operator` Deployment in the `starboard-operator` namespace:
+        kubectl logs deployment/starboard-operator -n starboard-operator
+   In case of any error consult our [Troubleshooting](./../../troubleshooting.md) guidelines.
 
-    kubectl get deployment -n starboard-operator
-
-You should see the output similar to the following:
-
-    NAME                 READY   UP-TO-DATE   AVAILABLE   AGE
-    starboard-operator   1/1     1            1           11m
-
-If for some reason it's not ready yet, check the logs of the Deployment for
-errors:
-
-    kubectl logs -n starboard-operator deployment/starboard-operator
-
-In case of any error consult our [Troubleshooting](./../../troubleshooting.md) guidelines.
+## Uninstall
 
 You can uninstall the operator with the following command:
 

--- a/docs/operator/installation/helm.md
+++ b/docs/operator/installation/helm.md
@@ -20,7 +20,7 @@ configure it to watch the `default` namespaces:
    the `starboard-operator` namespace. For example, you can use Trivy
    in [ClientServer](./../../integrations/vulnerability-scanners/trivy.md#clientserver) mode or
    [Aqua Enterprise](./../../integrations/vulnerability-scanners/aqua-enterprise.md) as an active vulnerability scanner.
-   If you skip this step, the operator will ensure [configuration objects](./../../configuration.md)
+   If you skip this step, the operator will ensure [configuration objects](./../../settings.md)
    on startup with the default settings.
 
         kubectl apply -f https://raw.githubusercontent.com/aquasecurity/starboard/main/deploy/static/05-starboard-operator.config.yaml

--- a/docs/operator/installation/kubectl.md
+++ b/docs/operator/installation/kubectl.md
@@ -18,9 +18,11 @@ watch the `default` namespace:
           -f https://raw.githubusercontent.com/aquasecurity/starboard/main/deploy/static/03-starboard-operator.clusterrole.yaml \
           -f https://raw.githubusercontent.com/aquasecurity/starboard/main/deploy/static/04-starboard-operator.clusterrolebinding.yaml
 
-3. (Optional) Configure the operator by creating the `starboard` ConfigMap and
-   the `starboard` secret in the `starboard-operator` namespace. If you skip
-   this step, the operator will ensure [configuration objects](./../../configuration.md)
+3. (Optional) Configure Starboard by creating the `starboard` ConfigMap and the `starboard` secret in
+   the `starboard-operator` namespace. For example, you can use Trivy
+   in [ClientServer](./../../integrations/vulnerability-scanners/trivy.md#clientserver) mode or
+   [Aqua Enterprise](./../../integrations/vulnerability-scanners/aqua-enterprise.md) as an active vulnerability scanner.
+   If you skip this step, the operator will ensure [configuration objects](./../../configuration.md)
    on startup with the default settings.
 
         kubectl apply -f https://raw.githubusercontent.com/aquasecurity/starboard/main/deploy/static/05-starboard-operator.config.yaml
@@ -34,22 +36,19 @@ watch the `default` namespace:
 
         kubectl apply -f https://raw.githubusercontent.com/aquasecurity/starboard/main/deploy/static/06-starboard-operator.deployment.yaml
 
-To confirm that the operator is running, check the number of replicas created by
-the `starboard-operator` Deployment in the `starboard-operator` namespace:
+5. To confirm that the operator is running, check the number of replicas created by
+   the `starboard-operator` Deployment in the `starboard-operator` namespace:
 
-    kubectl get deployment -n starboard-operator
+        kubectl get deployment -n starboard-operator
+        NAME                 READY   UP-TO-DATE   AVAILABLE   AGE
+        starboard-operator   1/1     1            1           11m
+   If for some reason it's not ready yet, check the logs of the Deployment for
+   errors:
 
-You should see the output similar to the following:
+        kubectl logs deployment/starboard-operator -n starboard-operator
+   In case of any error consult our [Troubleshooting](./../../troubleshooting.md) guidelines.
 
-    NAME                 READY   UP-TO-DATE   AVAILABLE   AGE
-    starboard-operator   1/1     1            1           11m
-
-If for some reason it's not ready yet, check the logs of the Deployment for
-errors:
-
-    kubectl logs -n starboard-operator deployment/starboard-operator
-
-In case of any error consult our [Troubleshooting](./../../troubleshooting.md) guidelines.
+## Uninstall
 
 You can uninstall the operator with the following command:
 

--- a/docs/operator/installation/kubectl.md
+++ b/docs/operator/installation/kubectl.md
@@ -22,7 +22,7 @@ watch the `default` namespace:
    the `starboard-operator` namespace. For example, you can use Trivy
    in [ClientServer](./../../integrations/vulnerability-scanners/trivy.md#clientserver) mode or
    [Aqua Enterprise](./../../integrations/vulnerability-scanners/aqua-enterprise.md) as an active vulnerability scanner.
-   If you skip this step, the operator will ensure [configuration objects](./../../configuration.md)
+   If you skip this step, the operator will ensure [configuration objects](./../../settings.md)
    on startup with the default settings.
 
         kubectl apply -f https://raw.githubusercontent.com/aquasecurity/starboard/main/deploy/static/05-starboard-operator.config.yaml

--- a/docs/operator/installation/olm.md
+++ b/docs/operator/installation/olm.md
@@ -31,7 +31,7 @@ multitenancy, and Subscription that links everything together to run the operato
    the `starboard-operator` namespace. For example, you can use Trivy
    in [ClientServer](./../../integrations/vulnerability-scanners/trivy.md#clientserver) mode or
    [Aqua Enterprise](./../../integrations/vulnerability-scanners/aqua-enterprise.md) as an active vulnerability scanner.
-   If you skip this step, the operator will ensure [configuration objects](./../../configuration.md)
+   If you skip this step, the operator will ensure [configuration objects](./../../settings.md)
    on startup with the default settings.
 
         kubectl apply -f https://raw.githubusercontent.com/aquasecurity/starboard/main/deploy/static/05-starboard-operator.config.yaml

--- a/docs/operator/installation/olm.md
+++ b/docs/operator/installation/olm.md
@@ -11,7 +11,6 @@ multitenancy, and Subscription that links everything together to run the operato
 
 2. Create the namespace to install the operator in:
 
-
         kubectl create ns starboard-operator
 
 3. Declare the target namespaces by creating the OperatorGroup:
@@ -28,7 +27,20 @@ multitenancy, and Subscription that links everything together to run the operato
           - default
         EOF
 
-4. Install the operator by creating the Subscription:
+4. (Optional) Configure Starboard by creating the `starboard` ConfigMap and the `starboard` secret in
+   the `starboard-operator` namespace. For example, you can use Trivy
+   in [ClientServer](./../../integrations/vulnerability-scanners/trivy.md#clientserver) mode or
+   [Aqua Enterprise](./../../integrations/vulnerability-scanners/aqua-enterprise.md) as an active vulnerability scanner.
+   If you skip this step, the operator will ensure [configuration objects](./../../configuration.md)
+   on startup with the default settings.
+
+        kubectl apply -f https://raw.githubusercontent.com/aquasecurity/starboard/main/deploy/static/05-starboard-operator.config.yaml
+   Review the default values and makes sure the operator is configured properly:
+
+        kubectl describe cm starboard -n starboard-operator
+        kubectl describe secret starboard -n starboard-operator
+
+5. Install the operator by creating the Subscription:
 
         cat << EOF | kubectl apply -f -
         apiVersion: operators.coreos.com/v1alpha1
@@ -41,13 +53,41 @@ multitenancy, and Subscription that links everything together to run the operato
           name: starboard-operator
           source: operatorhubio-catalog
           sourceNamespace: olm
+          config:
+            env:
+            - name: OPERATOR_SCAN_JOB_TIMEOUT
+              value: "60s"
+            - name: OPERATOR_CONCURRENT_SCAN_JOBS_LIMIT
+              value: "10"
+            - name: OPERATOR_LOG_DEV_MODE
+              value: "true"
         EOF
    The operator will be installed in the `starboard-operator` namespace and will be usable from the `default` namespace.
+   > **NOTE** The `spec.config` property allows you to override the default [configuration](./../configuration.md) of
+   > the operator's Deployment.
 
-5. After install, watch the operator come up using the following command:
+6. After install, watch the operator come up using the following command:
 
-        kubectl get csv -n starboard-operator
-        NAME                        DISPLAY              VERSION   REPLACES   PHASE
-        starboard-operator.v0.6.0   Starboard Operator   0.6.0                Succeeded
+        kubectl get clusterserviceversions -n starboard-operator
+        NAME                        DISPLAY              VERSION   REPLACES                    PHASE
+        starboard-operator.v0.8.0   Starboard Operator   0.8.0     starboard-operator.v0.7.0   Succeeded
+   If the above command succeeds and the ClusterServiceVersion has transitioned from `Installing` to `Succeeded` phase
+   you will also find the operator's Deployment in the same namespace where the Subscription is:
+
+        kubectl get deployments -n starboard-operator
+        NAME                 READY   UP-TO-DATE   AVAILABLE   AGE
+        starboard-operator   1/1     1            1           11m
+   If for some reason it's not ready yet, check the logs of the Deployment for errors:
+
+        kubectl logs deployment/starboard-operator -n starboard-operator
+   In case of any error consult our [Troubleshooting](./../../troubleshooting.md) guidelines.
+
+## Uninstall
+
+To uninstall the operator delete the Subscription, the ClusterServiceVersion, and the OperatorGroup:
+
+    kubectl delete subscription starboard-operator -n starboard-operator
+    kubectl delete clusterserviceversion starboard-operator.v0.8.0 -n starboard-operator
+    kubectl delete operatorgroup starboard-operator -n starboard-operator
 
 [olm]: https://github.com/operator-framework/operator-lifecycle-manager/

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -1,8 +1,9 @@
-# Configuration
+The Starboard CLI and Starboard Operator both read their configuration settings
+from a ConfigMap, as well as a secret that holds confidential settings (such as
+a GitHub token).
 
 The `starboard init` command creates the `starboard` ConfigMap and the
-`starboard` secret in the `starboard` namespace with default configuration
-settings.
+`starboard` secret in the `starboard` namespace with default settings.
 
 Similarly, the operator ensures the `starboard` ConfigMap and the `starboard`
 secret in the `OPERATOR_NAMESPACE`.
@@ -46,12 +47,11 @@ EOF
 )"
 ```
 
-The following tables list available configuration parameters with their default
-values.
+The following tables list available configuration settings with their default values.
 
 > **NOTE** You only need to configure the settings for the scanner you are using (i.e. `trivy.*` parameters are
-> used if `vulnerabilityReports.scanner` is set to `Trivy`). Check [integrations](./integrations.md) page to see
-> example configuration settings for common use cases.
+> used if `vulnerabilityReports.scanner` is set to `Trivy`). Check
+> [integrations](./integrations/vulnerability-scanners/index.md) page to see example configuration settings for common use cases.
 
 | CONFIGMAP KEY                  | DEFAULT                                                | DESCRIPTION |
 | ------------------------------ | ------------------------------------------------------ | ----------- |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,7 +24,7 @@ nav:
           - Operator Lifecycle Manager: operator/installation/olm.md
       - Getting Started: operator/getting-started.md
       - Configuration: operator/configuration.md
-  - Configuration: configuration.md
+  - Starboard Settings: settings.md
   - Integrations:
       - Vulnerability Scanners:
           - Overview: integrations/vulnerability-scanners/index.md


### PR DESCRIPTION
in the [lates version](https://operatorhub.io/operator/starboard-operator) we changed the way vulnerability scanners are configured.  Instead of using env the operator reads config objects in the namespace where it's installed.

You can preview docs by running `make mkdocs-serve`

Signed-off-by: Daniel Pacak <pacak.daniel@gmail.com>