### PR TITLE
feat(cli): Provide more details when scan job fails

### DIFF
--- a/pkg/kube/pod/manager.go
+++ b/pkg/kube/pod/manager.go
@@ -160,7 +160,7 @@ func (pw *Manager) GetPodByJob(ctx context.Context, job *batch.Job) (*core.Pod, 
 	if err != nil {
 		return nil, err
 	}
-	if len(podList.Items) > 0 {
+	if podList != nil && len(podList.Items) > 0 {
 		return &podList.Items[0], nil
 	}
 	return nil, nil

--- a/pkg/kube/pod/manager.go
+++ b/pkg/kube/pod/manager.go
@@ -5,16 +5,14 @@ import (
 	"fmt"
 	"io"
 
-	"k8s.io/klog"
-
 	"github.com/aquasecurity/starboard/pkg/kube"
-
 	apps "k8s.io/api/apps/v1"
 	batch "k8s.io/api/batch/v1"
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	core "k8s.io/api/core/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog"
 )
 
 type Manager struct {
@@ -123,6 +121,9 @@ func (pw *Manager) GetTerminatedContainersStatusesByJob(ctx context.Context, job
 
 func GetTerminatedContainersStatusesByPod(pod *core.Pod) map[string]*core.ContainerStateTerminated {
 	states := make(map[string]*core.ContainerStateTerminated)
+	if pod == nil {
+		return states
+	}
 	for _, status := range pod.Status.InitContainerStatuses {
 		if status.State.Terminated == nil {
 			continue
@@ -159,7 +160,10 @@ func (pw *Manager) GetPodByJob(ctx context.Context, job *batch.Job) (*core.Pod, 
 	if err != nil {
 		return nil, err
 	}
-	return &podList.Items[0], nil
+	if len(podList.Items) > 0 {
+		return &podList.Items[0], nil
+	}
+	return nil, nil
 }
 
 func (pw *Manager) GetPodLogs(ctx context.Context, pod *core.Pod, container string) (io.ReadCloser, error) {
@@ -185,17 +189,4 @@ func (pw *Manager) logTerminatedContainersErrors(statuses map[string]*core.Conta
 		}
 		klog.Errorf("Container %s terminated with %s: %s", container, status.Reason, status.Message)
 	}
-}
-
-// GetImages gets a slice of images for the specified PodSpec.
-func GetImages(spec core.PodSpec) (images []string) {
-	for _, c := range spec.InitContainers {
-		images = append(images, c.Image)
-	}
-
-	for _, c := range spec.Containers {
-		images = append(images, c.Image)
-	}
-
-	return
 }

--- a/pkg/vulnerabilityreport/scanner.go
+++ b/pkg/vulnerabilityreport/scanner.go
@@ -101,11 +101,6 @@ func (s *Scanner) Scan(ctx context.Context, workload kube.Object) ([]v1alpha1.Vu
 
 	klog.V(3).Infof("Scan job completed: %s/%s", job.Namespace, job.Name)
 
-	job, err = s.clientset.BatchV1().Jobs(job.Namespace).Get(ctx, job.Name, metav1.GetOptions{})
-	if err != nil {
-		return nil, fmt.Errorf("getting scan job: %w", err)
-	}
-
 	return s.getVulnerabilityReportsByScanJob(ctx, job, owner)
 }
 


### PR DESCRIPTION
It might happen that a scan job cannot be created. In such cases Starboard CLI hangs forever because it watches the job's status to terminate (JobComplete or JobFailed). However, some failures are reported as Kubernetes events associated with the scan job.

This change adds the events informer to watch events associated with a scan job, and terminate the program when the event of type EventTypeWarning (= error for Kubernetes) is detected.

To reproduce you can delete the starboard service account in the starborad namespace:

```
kubectl delete sa -n starboard starboard
```

## Before

```console
$ kubectl starboard generate vulnerabilityreports deploy/nginx -v 3
I0111 14:33:00.321886   35566 cert_rotation.go:137] Starting client certificate rotation controller
I0111 14:33:00.351359   35566 scanner.go:66] Getting Pod template for workload: {Deployment nginx default}
I0111 14:33:00.357111   35566 scanner.go:72] Scanning with options: {ScanJobTimeout:0s DeleteScanJob:true}
I0111 14:33:00.358993   35566 runner.go:79] Running task and waiting forever
I0111 14:33:00.359382   35566 runnable_job.go:72] Creating job "starboard/92506d31-46ed-4095-a1b1-822e5f076a42"
I0111 14:33:00.372751   35566 reflector.go:175] Starting reflector *v1.Job (30m0s) from pkg/mod/k8s.io/client-go@v0.18.6/tools/cache/reflector.go:125
I0111 14:33:00.372772   35566 reflector.go:211] Listing and watching *v1.Job from pkg/mod/k8s.io/client-go@v0.18.6/tools/cache/reflector.go:125
HANGS FOREVER !!!
```

## After

```console
$ ./bin/starboard generate vulnerabilityreports deploy/nginx -v 3
I0111 14:31:48.312623   35506 cert_rotation.go:137] Starting client certificate rotation controller
I0111 14:31:48.327276   35506 scanner.go:66] Getting Pod template for workload: {Deployment nginx default}
I0111 14:31:48.331739   35506 scanner.go:72] Scanning with options: {ScanJobTimeout:0s DeleteScanJob:true}
I0111 14:31:48.333309   35506 runner.go:79] Running task and waiting forever
I0111 14:31:48.333339   35506 runnable_job.go:73] Creating job "starboard/37dc6d47-e5bf-46c9-9888-400105710fc6"
I0111 14:31:48.339370   35506 reflector.go:175] Starting reflector *v1.Event (30m0s) from pkg/mod/k8s.io/client-go@v0.18.6/tools/cache/reflector.go:125
I0111 14:31:48.339388   35506 reflector.go:211] Listing and watching *v1.Event from pkg/mod/k8s.io/client-go@v0.18.6/tools/cache/reflector.go:125
I0111 14:31:48.339391   35506 reflector.go:175] Starting reflector *v1.Job (30m0s) from pkg/mod/k8s.io/client-go@v0.18.6/tools/cache/reflector.go:125
I0111 14:31:48.339409   35506 reflector.go:211] Listing and watching *v1.Job from pkg/mod/k8s.io/client-go@v0.18.6/tools/cache/reflector.go:125
I0111 14:31:48.439720   35506 runner.go:83] Stopping runner on task completion with error: warning event received: Error creating: pods "37dc6d47-e5bf-46c9-9888-400105710fc6-" is forbidden: error looking up service account starboard/starboard: serviceaccount "starboard" not found (FailedCreate)
error: running scan job: warning event received: Error creating: pods "37dc6d47-e5bf-46c9-9888-400105710fc6-" is forbidden: error looking up service account starboard/starboard: serviceaccount "starboard" not found (FailedCreate)
```

Resolves: #70

Signed-off-by: Daniel Pacak <pacak.daniel@gmail.com>