### PR TITLE
Add passing checks count to configauditreport summary

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.15
 require (
 	github.com/caarlos0/env/v6 v6.3.0
 	github.com/davecgh/go-spew v1.1.1
+	github.com/google/go-cmp v0.4.1
 	github.com/google/go-containerregistry v0.1.1
 	github.com/google/uuid v1.1.1
 	github.com/onsi/ginkgo v1.14.0

--- a/pkg/apis/aquasecurity/v1alpha1/config_audit_types.go
+++ b/pkg/apis/aquasecurity/v1alpha1/config_audit_types.go
@@ -52,6 +52,12 @@ var (
 					Name:     "Age",
 				},
 				{
+					JSONPath: ".report.summary.passCount",
+					Type:     "integer",
+					Name:     "Pass",
+					Priority: 1,
+				},
+				{
 					JSONPath: ".report.summary.dangerCount",
 					Type:     "integer",
 					Name:     "Danger",
@@ -74,6 +80,7 @@ const (
 )
 
 type ConfigAuditSummary struct {
+	PassCount    int `json:"passCount"`
 	DangerCount  int `json:"dangerCount"`
 	WarningCount int `json:"warningCount"`
 }

--- a/pkg/polaris/converter.go
+++ b/pkg/polaris/converter.go
@@ -33,11 +33,11 @@ func (c *converter) Convert(reader io.Reader) (v1alpha1.ConfigAuditResult, error
 	return c.toConfigAudit(report.Results[0])
 }
 
-// TODO Add success checks to the summary
 func (c *converter) toSummary(podChecks []v1alpha1.Check, containerChecks map[string][]v1alpha1.Check) v1alpha1.ConfigAuditSummary {
 	var summary v1alpha1.ConfigAuditSummary
 	for _, c := range podChecks {
 		if c.Success {
+			summary.PassCount++
 			continue
 		}
 		switch c.Severity {
@@ -50,6 +50,7 @@ func (c *converter) toSummary(podChecks []v1alpha1.Check, containerChecks map[st
 	for _, checks := range containerChecks {
 		for _, c := range checks {
 			if c.Success {
+				summary.PassCount++
 				continue
 			}
 			switch c.Severity {
@@ -87,7 +88,6 @@ func (c *converter) toConfigAudit(result Result) (v1alpha1.ConfigAuditResult, er
 				Severity: crr.Severity,
 				Category: crr.Category,
 			})
-
 		}
 		containerChecks[cr.Name] = checks
 	}

--- a/pkg/polaris/converter_test.go
+++ b/pkg/polaris/converter_test.go
@@ -7,62 +7,73 @@ import (
 	"github.com/aquasecurity/starboard/pkg/apis/aquasecurity/v1alpha1"
 	"github.com/aquasecurity/starboard/pkg/polaris"
 	"github.com/aquasecurity/starboard/pkg/starboard"
-	"github.com/stretchr/testify/assert"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"
 )
 
 func TestConverter_Convert(t *testing.T) {
-	// FIXME Deterministic assert!
-	t.Skip("Fix me - the assert is not deterministic")
 	file, err := os.Open("testdata/polaris-report.json")
 	require.NoError(t, err)
 	defer func() {
 		_ = file.Close()
 	}()
 
-	reports, err := polaris.NewConverter(starboard.ConfigData{}).Convert(file)
-	require.NoError(t, err)
-	assert.Equal(t, []v1alpha1.ConfigAuditResult{
-		{
-			Scanner: v1alpha1.Scanner{
-				Name:    "Polaris",
-				Vendor:  "Fairwinds",
-				Version: "latest",
+	want := v1alpha1.ConfigAuditResult{
+		Scanner: v1alpha1.Scanner{
+			Name:    "Polaris",
+			Vendor:  "Fairwinds Ops",
+			Version: "latest",
+		},
+		PodChecks: []v1alpha1.Check{
+			{
+				ID:       "hostIPCSet",
+				Message:  "Host IPC is not configured",
+				Success:  true,
+				Severity: "error",
+				Category: "Security",
 			},
-			PodChecks: []v1alpha1.Check{
+			{
+				ID:       "hostNetworkSet",
+				Message:  "Host network is not configured",
+				Success:  true,
+				Severity: "warning",
+				Category: "Networking",
+			},
+		},
+		ContainerChecks: map[string][]v1alpha1.Check{
+			"db": {
 				{
-					ID:       "hostIPCSet",
-					Message:  "Host IPC is not configured",
-					Success:  true,
-					Severity: "error",
-					Category: "Security",
-				},
-				{
-					ID:       "hostNetworkSet",
-					Message:  "Host network is not configured",
+					ID:       "cpuLimitsMissing",
+					Message:  "CPU limits are set",
 					Success:  true,
 					Severity: "warning",
-					Category: "Networking",
+					Category: "Resources",
 				},
-			},
-			ContainerChecks: map[string][]v1alpha1.Check{
-				"db": {
-					{
-						ID:       "cpuLimitsMissing",
-						Message:  "CPU limits are set",
-						Success:  true,
-						Severity: "warning",
-						Category: "Resources",
-					},
-					{
-						ID:       "cpuRequestsMissing",
-						Message:  "CPU requests are set",
-						Success:  true,
-						Severity: "warning",
-						Category: "Resources",
-					},
+				{
+					ID:       "cpuRequestsMissing",
+					Message:  "CPU requests are set",
+					Success:  true,
+					Severity: "warning",
+					Category: "Resources",
 				},
 			},
 		},
-	}, reports)
+		Summary: v1alpha1.ConfigAuditSummary{
+			PassCount: 4,
+		},
+	}
+
+	got, err := polaris.NewConverter(starboard.ConfigData{
+		"polaris.imageRef": "latest",
+	}).Convert(file)
+	require.NoError(t, err)
+
+	if diff := cmp.Diff(want, got,
+		cmpopts.IgnoreFields(v1alpha1.ConfigAuditResult{}, "UpdateTimestamp"),
+		cmpopts.SortSlices(func(a, b v1alpha1.Check) bool {
+			return a.ID < b.ID
+		})); diff != "" {
+		t.Errorf("diff (-want, +got): %v\n", diff)
+	}
 }


### PR DESCRIPTION
Fixes #334.

Here is the output I get for the `nginx` deployment from the [getting started](https://aquasecurity.github.io/starboard/cli/getting-started/) docs:

```shell
$ kubectl create deployment nginx --image nginx:1.16
$ starboard scan vulnerabilityreports deployment/nginx
$ kubectl get configauditreports.aquasecurity.github.io -o wide
NAME               SCANNER   AGE   PASS   DANGER   WARNING
deployment-nginx   Polaris   1s    9      0        8
```

In order to test my changes, I modified the existing test in `pkg/polaris/converter_test.go`. The test was being skipped due to being nondeterministic, so I fixed the nondeterminism. I was also having issues reading the error output when using `assert.Equal`, so I brought in `google/go-cmp` to get a rich diff. Let me know if that is undesirable for any reason.

## Future work

While writing the test for the passing checks, I noticed what seems to be an error in `testdata/polaris-report.json`: one of the reports uses `"Severity": "error"`, but judging from [Polaris docs](https://polaris.docs.fairwinds.com/checks/security/) that should be `"Severity": "danger"`.

Also, all the results have `"Success": true`, so the code that increments the `DangerCount` and `WarningCount` in the `ConfigAuditSummary` is not currently being exercised.

I would be happy to fix these issues in additional PRs, if desired.