### PR TITLE
Add passing checks count to configauditreport summary

### DIFF
--- a/pkg/apis/aquasecurity/v1alpha1/config_audit_types.go
+++ b/pkg/apis/aquasecurity/v1alpha1/config_audit_types.go
@@ -52,6 +52,12 @@ var (
 					Name:     "Age",
 				},
 				{
+					JSONPath: ".report.summary.passCount",
+					Type:     "integer",
+					Name:     "Pass",
+					Priority: 1,
+				},
+				{
 					JSONPath: ".report.summary.dangerCount",
 					Type:     "integer",
 					Name:     "Danger",
@@ -74,6 +80,7 @@ const (
 )
 
 type ConfigAuditSummary struct {
+	PassCount    int `json:"passCount"`
 	DangerCount  int `json:"dangerCount"`
 	WarningCount int `json:"warningCount"`
 }

--- a/pkg/polaris/plugin.go
+++ b/pkg/polaris/plugin.go
@@ -177,11 +177,11 @@ func (p *plugin) configAuditResultFrom(result Result) (v1alpha1.ConfigAuditResul
 	}, nil
 }
 
-// TODO Add success checks count to the ConfigAuditSummary
 func (p *plugin) configAuditSummaryFrom(podChecks []v1alpha1.Check, containerChecks map[string][]v1alpha1.Check) v1alpha1.ConfigAuditSummary {
 	var summary v1alpha1.ConfigAuditSummary
 	for _, c := range podChecks {
 		if c.Success {
+			summary.PassCount++
 			continue
 		}
 		switch c.Severity {
@@ -194,6 +194,7 @@ func (p *plugin) configAuditSummaryFrom(podChecks []v1alpha1.Check, containerChe
 	for _, checks := range containerChecks {
 		for _, c := range checks {
 			if c.Success {
+				summary.PassCount++
 				continue
 			}
 			switch c.Severity {

--- a/pkg/polaris/plugin_test.go
+++ b/pkg/polaris/plugin_test.go
@@ -137,6 +137,7 @@ func TestPlugin_ParseConfigAuditResult(t *testing.T) {
 		Version: "3.0",
 	}, result.Scanner)
 	assert.Equal(t, v1alpha1.ConfigAuditSummary{
+		PassCount:    2,
 		DangerCount:  1,
 		WarningCount: 1,
 	}, result.Summary)


### PR DESCRIPTION
Fixes #334.

Here is the output I get for the `nginx` deployment from the [getting started](https://aquasecurity.github.io/starboard/cli/getting-started/) docs:

```shell
$ kubectl create deployment nginx --image nginx:1.16
$ starboard scan vulnerabilityreports deployment/nginx
$ kubectl get configauditreports.aquasecurity.github.io -o wide
NAME               SCANNER   AGE   PASS   DANGER   WARNING
deployment-nginx   Polaris   1s    9      0        8
```