### PR TITLE
Set security context for trivy

### DIFF
--- a/pkg/trivy/plugin.go
+++ b/pkg/trivy/plugin.go
@@ -250,6 +250,14 @@ func (s *scanner) getPodSpecForStandaloneMode(spec corev1.PodSpec, credentials m
 					MountPath: "/var/lib/trivy",
 				},
 			},
+			SecurityContext: &corev1.SecurityContext{
+				Privileged:               pointer.BoolPtr(false),
+				AllowPrivilegeEscalation: pointer.BoolPtr(false),
+				Capabilities: &corev1.Capabilities{
+					Drop: []corev1.Capability{"all"},
+				},
+				ReadOnlyRootFilesystem: pointer.BoolPtr(true),
+			},
 		})
 	}
 
@@ -269,6 +277,13 @@ func (s *scanner) getPodSpecForStandaloneMode(spec corev1.PodSpec, credentials m
 		},
 		InitContainers: []corev1.Container{initContainer},
 		Containers:     containers,
+		SecurityContext: &corev1.PodSecurityContext{
+			RunAsUser:  pointer.Int64Ptr(1000),
+			RunAsGroup: pointer.Int64Ptr(1000),
+			SeccompProfile: &corev1.SeccompProfile{
+				Type: corev1.SeccompProfileTypeRuntimeDefault,
+			},
+		},
 	}, secrets, nil
 }
 

--- a/pkg/trivy/plugin_test.go
+++ b/pkg/trivy/plugin_test.go
@@ -168,6 +168,21 @@ func TestScanner_GetScanJobSpec(t *testing.T) {
 								MountPath: "/var/lib/trivy",
 							},
 						},
+						SecurityContext: &corev1.SecurityContext{
+							Privileged:               pointer.BoolPtr(false),
+							AllowPrivilegeEscalation: pointer.BoolPtr(false),
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"all"},
+							},
+							ReadOnlyRootFilesystem: pointer.BoolPtr(true),
+						},
+					},
+				},
+				SecurityContext: &corev1.PodSecurityContext{
+					RunAsUser:  pointer.Int64Ptr(1000),
+					RunAsGroup: pointer.Int64Ptr(1000),
+					SeccompProfile: &corev1.SeccompProfile{
+						Type: corev1.SeccompProfileTypeRuntimeDefault,
 					},
 				},
 			},


### PR DESCRIPTION
This PR adds SecurityContexts to the `trivy` Job in order to run the job with the least amount of privilege possible, in partial fulfillment of #163.

I ran the job with and without the changes in a local kind cluster and I did not see a difference in the output.

To obtain the output, I ran:
```
kubectl create deployment nginx --image nginx:1.16
kubectl wait --for=condition=available deploy/nginx --timeout=60s
./bin/starboard scan vulnerabilityreports deployment/nginx
./bin/starboard get vulnerabilities deployment/nginx -o yaml >vulns.yaml
```

---

Looking at issues on the `trivy` repo, I found this issue: https://github.com/aquasecurity/trivy/issues/580, where running as a non-root user was causing `trivy` to be unable to run. It seems that this was due to using the Docker socket, which is not the case in `starboard`, so I don't think this could cause problems here.