### PR TITLE
Set security context for polaris

### DIFF
--- a/pkg/polaris/plugin.go
+++ b/pkg/polaris/plugin.go
@@ -93,6 +93,21 @@ func (p *plugin) GetScanJobSpec(workload kube.Object, gvk schema.GroupVersionKin
 					"--config", "/etc/starboard/polaris.config.yaml",
 					"--resource", sourceName,
 				},
+				SecurityContext: &corev1.SecurityContext{
+					Privileged:               pointer.BoolPtr(false),
+					AllowPrivilegeEscalation: pointer.BoolPtr(false),
+					Capabilities: &corev1.Capabilities{
+						Drop: []corev1.Capability{"all"},
+					},
+					ReadOnlyRootFilesystem: pointer.BoolPtr(true),
+				},
+			},
+		},
+		SecurityContext: &corev1.PodSecurityContext{
+			RunAsUser:  pointer.Int64Ptr(1000),
+			RunAsGroup: pointer.Int64Ptr(1000),
+			SeccompProfile: &corev1.SeccompProfile{
+				Type: corev1.SeccompProfileTypeRuntimeDefault,
 			},
 		},
 	}, nil

--- a/pkg/polaris/plugin_test.go
+++ b/pkg/polaris/plugin_test.go
@@ -95,6 +95,21 @@ func TestPlugin_GetScanJobSpec(t *testing.T) {
 							"--config", "/etc/starboard/polaris.config.yaml",
 							"--resource", "default/Deployment.apps/v1/nginx",
 						},
+						SecurityContext: &corev1.SecurityContext{
+							Privileged:               pointer.BoolPtr(false),
+							AllowPrivilegeEscalation: pointer.BoolPtr(false),
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"all"},
+							},
+							ReadOnlyRootFilesystem: pointer.BoolPtr(true),
+						},
+					},
+				},
+				SecurityContext: &corev1.PodSecurityContext{
+					RunAsUser:  pointer.Int64Ptr(1000),
+					RunAsGroup: pointer.Int64Ptr(1000),
+					SeccompProfile: &corev1.SeccompProfile{
+						Type: corev1.SeccompProfileTypeRuntimeDefault,
 					},
 				},
 			},


### PR DESCRIPTION
This PR adds SecurityContexts to the `polaris` Job in order to run the job with the least amount of privilege possible, in partial fulfillment of #163.

I ran the job with and without the changes in a local kind cluster and I did not see a difference in the output.

To obtain the output, I ran:
```
kubectl create deployment nginx --image nginx:1.16
kubectl wait --for=condition=available deploy/nginx --timeout=60s
./bin/starboard scan configauditreports deployment/nginx
./bin/starboard get configaudit deployment/nginx -o yaml >cars.yaml
```