### PR TITLE
fix: Save security reports for static pods

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,13 +66,15 @@ itests-starboard: check-env get-ginkgo
 	--v \
 	-coverprofile=coverage.txt \
 	-coverpkg=github.com/aquasecurity/starboard/pkg/cmd,\
+	github.com/aquasecurity/starboard/pkg/config,\
+	github.com/aquasecurity/starboard/pkg/resources,\
 	github.com/aquasecurity/starboard/pkg/kube,\
 	github.com/aquasecurity/starboard/pkg/kube/pod,\
 	github.com/aquasecurity/starboard/pkg/kubebench,\
 	github.com/aquasecurity/starboard/pkg/kubehunter,\
+	github.com/aquasecurity/starboard/pkg/trivy,\
 	github.com/aquasecurity/starboard/pkg/polaris,\
 	github.com/aquasecurity/starboard/pkg/configauditreport,\
-	github.com/aquasecurity/starboard/pkg/trivy,\
 	github.com/aquasecurity/starboard/pkg/vulnerabilityreport \
 	./itest/starboard
 
@@ -88,7 +90,11 @@ itests-starboard-operator: check-env get-ginkgo
 	github.com/aquasecurity/starboard/pkg/operator/controller,\
 	github.com/aquasecurity/starboard/pkg/operator/controller/job,\
 	github.com/aquasecurity/starboard/pkg/operator/controller/pod,\
+	github.com/aquasecurity/starboard/pkg/config,\
+	github.com/aquasecurity/starboard/pkg/resources,\
 	github.com/aquasecurity/starboard/pkg/trivy,\
+	github.com/aquasecurity/starboard/pkg/polaris,\
+	github.com/aquasecurity/starboard/pkg/configauditreport,\
 	github.com/aquasecurity/starboard/pkg/vulnerabilityreport \
 	./itest/starboard-operator
 

--- a/pkg/resources/doc.go
+++ b/pkg/resources/doc.go
@@ -1,0 +1,3 @@
+// This package provides primitives for working with Kubernetes objects.
+// TODO We should merge this package with the kube package.
+package resources

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -41,7 +41,7 @@ func GetContainerImagesFromJob(job *batchv1.Job) (kube.ContainerImages, error) {
 // ReplicaSet, whereas for an unmanaged pod the immediate owner is the pod
 // itself.
 //
-// Note that kublet can manage pods independently by reading pod definition
+// Note that kubelet can manage pods independently by reading pod definition
 // files from a configured host directory (typically /etc/kubernetes/manifests).
 // Such pods are called *static pods* and are owned by a cluster Node.
 // In this case we treat them as unmanaged pods. (Otherwise we'd require

--- a/pkg/resources/resources_test.go
+++ b/pkg/resources/resources_test.go
@@ -4,10 +4,89 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/aquasecurity/starboard/pkg/kube"
 	"github.com/aquasecurity/starboard/pkg/resources"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
 )
+
+func TestGetImmediateOwnerReference(t *testing.T) {
+
+	testCases := []struct {
+		name          string
+		pod           *corev1.Pod
+		expectedOwner kube.Object
+	}{
+		{
+			name: "Should return pod as owner of unmanaged pod",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "foo",
+					Name:      "unmanaged-pod",
+				},
+			},
+			expectedOwner: kube.Object{
+				Kind:      "Pod",
+				Namespace: "foo",
+				Name:      "unmanaged-pod",
+			},
+		},
+		{
+			name: "Should return ReplicaSet as owner of pod managed by Deployment",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "bar",
+					Name:      "nginx-6d4cf56db6-8g9j6",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: "apps/v1",
+							Kind:       "ReplicaSet",
+							Name:       "nginx-6d4cf56db6",
+							Controller: pointer.BoolPtr(true),
+						},
+					},
+				},
+			},
+			expectedOwner: kube.Object{
+				Kind:      "ReplicaSet",
+				Namespace: "bar",
+				Name:      "nginx-6d4cf56db6",
+			},
+		},
+		{
+			name: "Should return pod as owner of static pod managed by kubelet",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "kube-system",
+					Name:      "etcd-kind-control-plane",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: "v1",
+							Kind:       "Node",
+							Name:       "kind-control-plane",
+							Controller: pointer.BoolPtr(true),
+						},
+					},
+				},
+			},
+			expectedOwner: kube.Object{
+				Kind:      "Pod",
+				Namespace: "kube-system",
+				Name:      "etcd-kind-control-plane",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			owner := resources.GetImmediateOwnerReference(tc.pod)
+			assert.Equal(t, tc.expectedOwner, owner)
+		})
+	}
+
+}
 
 func TestComputeHash(t *testing.T) {
 


### PR DESCRIPTION
Note that kublet can manage pods independently by reading pod definition
files from a configured host directory (typically /etc/kubernetes/manifests).
Such pods are called *static pods* and are owned by a cluster Node.
So far we could not save vulnerability and config audit reports for such pods.

In this commit we treat them as unmanaged pods. (Otherwise we'd require
cluster-scoped permissions to get Nodes in order to set the owner reference
when we create an instance of custom resource.)

Resolves: #234

Signed-off-by: Daniel Pacak <pacak.daniel@gmail.com>