### PR TITLE
feat: Manage pods controlled by third parties

### DIFF
--- a/pkg/resources/resources_test.go
+++ b/pkg/resources/resources_test.go
@@ -77,6 +77,28 @@ func TestGetImmediateOwnerReference(t *testing.T) {
 				Name:      "etcd-kind-control-plane",
 			},
 		},
+		{
+			name: "Should return pod as owner of pod managed by third party workload",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "dev",
+					Name:      "hello-world-argo",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: "argoproj.io/v1alpha1",
+							Kind:       "Workflow",
+							Name:       "hello-world-argo-r99sq",
+							Controller: pointer.BoolPtr(true),
+						},
+					},
+				},
+			},
+			expectedOwner: kube.Object{
+				Kind:      "Pod",
+				Namespace: "dev",
+				Name:      "hello-world-argo",
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Pods created and controlled by third party frameworks,
such as Argo workflow engine, are considered as unmanaged.
Otherwise we'd need to maintain and extend the list of
RBAC permissions over time.

Resolves: #373

Signed-off-by: Daniel Pacak <pacak.daniel@gmail.com>