### PR TITLE
Make kubehunter quick config param optional

### DIFF
--- a/pkg/starboard/config.go
+++ b/pkg/starboard/config.go
@@ -331,9 +331,9 @@ func (c ConfigData) GetKubeHunterImageRef() (string, error) {
 }
 
 func (c ConfigData) GetKubeHunterQuick() (bool, error) {
-	val, err := c.getRequiredProperty("kube-hunter.quick")
-	if err != nil {
-		return false, err
+	val, ok := c["kube-hunter.quick"]
+	if !ok {
+		return false, nil
 	}
 	if val != "false" && val != "true" {
 		return false, fmt.Errorf("property kube-hunter.quick must be either \"false\" or \"true\", got %q", val)

--- a/pkg/starboard/config_test.go
+++ b/pkg/starboard/config_test.go
@@ -158,11 +158,11 @@ func TestConfigData_GetKubeHunterQuick(t *testing.T) {
 		expectedQuick bool
 	}{
 		{
-			name:          "Should return error",
+			name:          "Should return false when parameter is not set",
 			configData:    starboard.ConfigData{},
-			expectedError: "property kube-hunter.quick not set",
+			expectedQuick: false,
 		}, {
-			name: "Should return error when when quick is set to something other than \"false\" or \"true\" in config data",
+			name: "Should return error when quick is set to something other than \"false\" or \"true\" in config data",
 			configData: starboard.ConfigData{
 				"kube-hunter.quick": "not-a-boolean",
 			},


### PR DESCRIPTION
This PR addresses a potential issue with the `kube-hunter.quick` configuration param. It doesn't make much sense for this parameter to be required, since it's a fairly specific setting that a significant portion of users may not care about.

(This PR was inspired by https://github.com/aquasecurity/starboard/discussions/386.)