### PR TITLE
chore(release): remove logout step

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -112,10 +112,5 @@ jobs:
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Log out from docker.io and ECR registries
-        if: ${{ always() }}
-        run: |
-          docker logout docker.io
-          docker logout public.ecr.aws
       - name: Update new version for plugin 'starboard' in krew-index
         uses: rajatjindal/krew-release-bot@v0.0.38


### PR DESCRIPTION
If I understand correctly, `docker/login-action@v1` log out from the Docker registry by default. Am I missing something?
https://github.com/docker/login-action#inputs

![image](https://user-images.githubusercontent.com/2253692/108676504-fc5f2900-74f0-11eb-949f-0cecc0cf7c72.png)
https://github.com/aquasecurity/starboard/runs/1901817059?check_suite_focus=true