### PR TITLE
doc: Update cli docs to show the correct command to get configaudit

### DIFF
--- a/docs/cli/getting-started.md
+++ b/docs/cli/getting-started.md
@@ -87,7 +87,7 @@ starboard scan configauditreports deployment/nginx
 Retrieve the configuration audit report:
 
 ```
-starboard get configauditreport deployment/nginx -o yaml
+starboard get configaudit deployment/nginx -o yaml
 ```
 
 or


### PR DESCRIPTION
Just a minor doc fix: The correct command is `starboard get configaudit`, but the doc said `starboard get configauditreport`. This PR updates the doc to match the command.