### PR TITLE
doc: Clarify prereqs and env vars to run operator integration tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,10 +138,13 @@ To open the test coverage report in your web browser, run:
 $ go tool cover -html=itest/starboard/coverage.txt
 ```
 
-Similarly, to run the integration tests for Starboard Operator and view the coverage report, run:
+To run the integration tests for Starboard Operator and view the coverage report, first do the [prerequisite steps](https://github.com/aquasecurity/starboard/blob/main/CONTRIBUTING.md#prerequisites), and then run:
 
 ```
-$ make itests-starboard-operator
+$ OPERATOR_NAMESPACE=starboard-operator \
+     OPERATOR_TARGET_NAMESPACES=default \
+     OPERATOR_LOG_DEV_MODE=true \
+     make itests-starboard-operator
 $ go tool cover -html=itest/starboard-operator/coverage.txt
 ```
 


### PR DESCRIPTION
Without the OPERATOR_NAMESPACE env var, operator integration tests fail with messages like: 
```
    Unexpected error:
        <*fmt.wrapError | 0xc0005b4400>: {
            msg: "resolving install mode: OPERATOR_NAMESPACE must be set",
            err: {
                s: "OPERATOR_NAMESPACE must be set",
            },
        }
        resolving install mode: OPERATOR_NAMESPACE must be set
    occurred
```

Without first running the prerequisite steps to add the starboard-operator namespace to the cluster, operator integration tests fails with messages like:
```
    Unexpected error:
        <*errors.StatusError | 0xc000738f00>: {
            ErrStatus: {
                TypeMeta: {Kind: "", APIVersion: ""},
                ListMeta: {
                    SelfLink: "",
                    ResourceVersion: "",
                    Continue: "",
                    RemainingItemCount: nil,
                },
                Status: "Failure",
                Message: "namespaces \"starboard-operator\" not found",
                Reason: "NotFound",
                Details: {
                    Name: "starboard-operator",
                    Group: "",
                    Kind: "namespaces",
                    UID: "",
                    Causes: nil,
                    RetryAfterSeconds: 0,
                },
                Code: 404,
            },
        }
        namespaces "starboard-operator" not found
    occurred
```