### PR TITLE
fix: Polaris results parse failed(#449)

### DIFF
--- a/pkg/ext/json.go
+++ b/pkg/ext/json.go
@@ -1,0 +1,37 @@
+package ext
+
+import "io"
+
+type JsonReader struct {
+	reader  io.ReadCloser
+	started bool
+}
+
+// NewJsonReader constructs a new instant of JsonReader, which will try to match a start characator of
+// "{" or "[" as beginning of the json stream.
+func NewJsonReader(reader io.ReadCloser) io.ReadCloser {
+	return &JsonReader{reader: reader}
+}
+
+func (j *JsonReader) Read(p []byte) (n int, err error) {
+	if j.started {
+		return j.reader.Read(p)
+	}
+	var c = make([]byte, len(p))
+	for ; err == nil; n, err = j.reader.Read(c) {
+		i := 0
+		for ; i < n; i++ {
+			if c[i] == '{' || c[i] == '[' {
+				j.started = true
+				copy(p, c[i:])
+				return n - i, err
+			}
+		}
+	}
+
+	return n, err
+}
+
+func (j *JsonReader) Close() error {
+	return j.reader.Close()
+}

--- a/pkg/plugin/polaris/plugin.go
+++ b/pkg/plugin/polaris/plugin.go
@@ -117,8 +117,9 @@ func (p *plugin) GetContainerName() string {
 }
 
 func (p *plugin) ParseConfigAuditReportData(logsReader io.ReadCloser) (v1alpha1.ConfigAuditResult, error) {
+	jsonReader := ext.NewJsonReader(logsReader)
 	var report Report
-	err := json.NewDecoder(logsReader).Decode(&report)
+	err := json.NewDecoder(jsonReader).Decode(&report)
 	if err != nil {
 		return v1alpha1.ConfigAuditResult{}, err
 	}


### PR DESCRIPTION
Resolves #449

**What's in the pull request?**
I have created a wrap of _io.Reader_ that can skips invalid characters. it's a very simple solution without additionnally memory copy/ or type convert. (I tried to use a regex by converting the stream to string, but it seems like not necessary.). 
Please feed free to close the pull request if there's a better way.
