### PR TITLE
refactor(conftest): Skip rescan when plugin ConfigMap is deleted

### DIFF
--- a/pkg/operator/controller/plugins_config.go
+++ b/pkg/operator/controller/plugins_config.go
@@ -3,7 +3,6 @@ package controller
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/aquasecurity/starboard/pkg/apis/aquasecurity/v1alpha1"
 	"github.com/aquasecurity/starboard/pkg/configauditreport"
@@ -32,17 +31,13 @@ func (r *PluginsConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&corev1.ConfigMap{}, builder.WithPredicates(
 			predicate.Not(predicate.IsBeingTerminated),
+			predicate.HasName(starboard.GetPluginConfigMapName(r.PluginContext.GetName())),
 			predicate.InNamespace(r.Config.Namespace))).
 		Complete(r)
 }
 
 func (r *PluginsConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := r.Logger.WithValues("configMap", req.NamespacedName)
-
-	// TODO Use Predicate instead
-	if req.Name != "starboard-"+strings.ToLower(r.PluginContext.GetName())+"-config" {
-		return ctrl.Result{}, nil
-	}
 
 	cm := &corev1.ConfigMap{}
 

--- a/pkg/operator/predicate/predicate.go
+++ b/pkg/operator/predicate/predicate.go
@@ -42,6 +42,14 @@ var InstallModePredicate = func(config etc.Config) (predicate.Predicate, error) 
 	}), nil
 }
 
+// HasName is predicate.Predicate that returns true if the
+// specified client.Object has the desired name.
+var HasName = func(name string) predicate.Predicate {
+	return predicate.NewPredicateFuncs(func(obj client.Object) bool {
+		return name == obj.GetName()
+	})
+}
+
 // InNamespace is a predicate.Predicate that returns true if the
 // specified client.Object is in the desired namespace.
 var InNamespace = func(namespace string) predicate.Predicate {
@@ -68,8 +76,8 @@ var IsBeingTerminated = predicate.NewPredicateFuncs(func(obj client.Object) bool
 	return obj.GetDeletionTimestamp() != nil
 })
 
-// JobHasConditions is a predicate.Predicate that returns true if the
-// specified client.Object is a batchv1.Job with any batchv1.JobConditionType.
+// JobHasAnyCondition is a predicate.Predicate that returns true if the
+// specified client.Object is a v1.Job with any v1.JobConditionType.
 var JobHasAnyCondition = predicate.NewPredicateFuncs(func(obj client.Object) bool {
 	if job, ok := obj.(*batchv1.Job); ok {
 		return len(job.Status.Conditions) > 0

--- a/pkg/operator/predicate/predicate_test.go
+++ b/pkg/operator/predicate/predicate_test.go
@@ -121,6 +121,43 @@ var _ = Describe("Predicate", func() {
 		})
 	})
 
+	Describe("When checking a HasName predicate", func() {
+
+		Context("When object has desired name", func() {
+
+			It("Should return true", func() {
+				instance := predicate.HasName("starboard-polaris-config")
+				obj := &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "starboard-polaris-config",
+					},
+				}
+
+				Expect(instance.Create(event.CreateEvent{Object: obj})).To(BeTrue())
+				Expect(instance.Update(event.UpdateEvent{ObjectNew: obj})).To(BeTrue())
+				Expect(instance.Delete(event.DeleteEvent{Object: obj})).To(BeTrue())
+				Expect(instance.Generic(event.GenericEvent{Object: obj})).To(BeTrue())
+			})
+		})
+
+		Context("When object does not have desired name", func() {
+
+			It("Should return false", func() {
+				instance := predicate.HasName("starboard-conftest-config")
+				obj := &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "starboard",
+					},
+				}
+
+				Expect(instance.Create(event.CreateEvent{Object: obj})).To(BeFalse())
+				Expect(instance.Update(event.UpdateEvent{ObjectNew: obj})).To(BeFalse())
+				Expect(instance.Delete(event.DeleteEvent{Object: obj})).To(BeFalse())
+				Expect(instance.Generic(event.GenericEvent{Object: obj})).To(BeFalse())
+			})
+		})
+	})
+
 	Describe("When checking a InNamespace predicate", func() {
 
 		Context("When object is in desired namespace", func() {

--- a/pkg/plugin/conftest/plugin.go
+++ b/pkg/plugin/conftest/plugin.go
@@ -115,7 +115,7 @@ func (p *plugin) GetScanJobSpec(ctx starboard.PluginContext, obj client.Object) 
 				VolumeSource: corev1.VolumeSource{
 					ConfigMap: &corev1.ConfigMapVolumeSource{
 						LocalObjectReference: corev1.LocalObjectReference{
-							Name: "starboard-conftest-config",
+							Name: starboard.GetPluginConfigMapName(ctx.GetName()),
 						},
 						Items: volumeItems,
 					},

--- a/pkg/starboard/plugin.go
+++ b/pkg/starboard/plugin.go
@@ -26,6 +26,12 @@ type PluginContext interface {
 	GetServiceAccountName() string
 }
 
+// GetPluginConfigMapName returns the name of a ConfigMap used to configure a plugin
+// with the given name.
+func GetPluginConfigMapName(pluginName string) string {
+	return "starboard-" + strings.ToLower(pluginName) + "-config"
+}
+
 type pluginContext struct {
 	name               string
 	client             client.Client

--- a/pkg/starboard/plugin_test.go
+++ b/pkg/starboard/plugin_test.go
@@ -10,6 +10,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
+func TestGetPluginConfigMapName(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	name := starboard.GetPluginConfigMapName("Conftest")
+	g.Expect(name).To(gomega.Equal("starboard-conftest-config"))
+}
+
 func TestPluginContext_GetConfig(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 


### PR DESCRIPTION
This wasn't an issue and we were handling ConfigMap deletion as
expected. However, I took this oportunity to refactor the code
a bit and use predicate instead of conditionally ingoring ConfigMap
events in the reconciliation loop. With predicate the events that
we're not interested in are not even added to the worker queue.

Resolves: #482