### PR TITLE
fix(Conftest): Do not specify UID (1000) and GID (1000) in SecurityContext

### DIFF
--- a/itest/starboard/starboard_cli_test.go
+++ b/itest/starboard/starboard_cli_test.go
@@ -757,7 +757,7 @@ var _ = Describe("Starboard CLI", func() {
 						err := cmd.Run(versionInfo, []string{
 							"starboard", "get", "vulnerabilities",
 							"deployment/" + deploy.Name,
-							"--namespace", namespaceItest,
+							"--namespace", testNamespace.Name,
 							"-v", starboardCLILogLevel,
 						}, stdout, stderr)
 						Expect(err).ToNot(HaveOccurred())
@@ -784,7 +784,7 @@ var _ = Describe("Starboard CLI", func() {
 						err := cmd.Run(versionInfo, []string{
 							"starboard", "get", "vulnerabilities",
 							"replicaset/" + replicasetName,
-							"--namespace", namespaceItest,
+							"--namespace", testNamespace.Name,
 							"-v", starboardCLILogLevel,
 						}, stdout, stderr)
 						Expect(err).ToNot(HaveOccurred())
@@ -811,7 +811,7 @@ var _ = Describe("Starboard CLI", func() {
 						err := cmd.Run(versionInfo, []string{
 							"starboard", "get", "vulnerabilities",
 							"pod/" + podName,
-							"--namespace", namespaceItest,
+							"--namespace", testNamespace.Name,
 							"-v", starboardCLILogLevel,
 						}, stdout, stderr)
 						Expect(err).ToNot(HaveOccurred())

--- a/itest/starboard/suite_test.go
+++ b/itest/starboard/suite_test.go
@@ -17,8 +17,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const namespaceItest = "starboard-itest"
-
 var (
 	kubeClient             client.Client
 	apiextensionsClientset apiextensions.ApiextensionsV1beta1Interface
@@ -34,7 +32,7 @@ var (
 	}
 	testNamespace = &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: namespaceItest,
+			Name: "starboard-itest",
 		},
 	}
 
@@ -44,7 +42,7 @@ var (
 			Namespace: "starboard",
 		},
 		Data: map[string]string{
-			"conftest.policy.kubernetes": `
+			"conftest.policy.runs_as_root.rego": `
 	package main
     
     deny[msg] {

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -26,8 +26,6 @@ var (
 )
 
 func Run(buildInfo starboard.BuildInfo, operatorConfig etc.Config) error {
-	setupLog.Info("Starting operator", "buildInfo", buildInfo)
-
 	installMode, operatorNamespace, targetNamespaces, err := operatorConfig.ResolveInstallMode()
 	if err != nil {
 		return fmt.Errorf("resolving install mode: %w", err)

--- a/pkg/plugin/conftest/plugin.go
+++ b/pkg/plugin/conftest/plugin.go
@@ -166,13 +166,7 @@ func (p *plugin) GetScanJobSpec(ctx starboard.PluginContext, obj client.Object) 
 					},
 				},
 			},
-			SecurityContext: &corev1.PodSecurityContext{
-				RunAsUser:  pointer.Int64Ptr(1000),
-				RunAsGroup: pointer.Int64Ptr(1000),
-				SeccompProfile: &corev1.SeccompProfile{
-					Type: corev1.SeccompProfileTypeRuntimeDefault,
-				},
-			},
+			SecurityContext: &corev1.PodSecurityContext{},
 		}, []*corev1.Secret{{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      secretName,

--- a/pkg/plugin/conftest/plugin_test.go
+++ b/pkg/plugin/conftest/plugin_test.go
@@ -146,13 +146,7 @@ func TestPlugin_GetScanJobSpec(t *testing.T) {
 				}),
 			}),
 		),
-		"SecurityContext": Equal(&corev1.PodSecurityContext{
-			RunAsUser:  pointer.Int64Ptr(1000),
-			RunAsGroup: pointer.Int64Ptr(1000),
-			SeccompProfile: &corev1.SeccompProfile{
-				Type: corev1.SeccompProfileTypeRuntimeDefault,
-			},
-		}),
+		"SecurityContext": Equal(&corev1.PodSecurityContext{}),
 	}))
 	g.Expect(*jobSpec.Volumes[0].VolumeSource.Secret).To(MatchFields(IgnoreExtras, Fields{
 		"SecretName": Equal("00000000-0000-0000-0000-000000000001"),


### PR DESCRIPTION
For upstream K8s cluster scan Jobs will run as USER defined in
the Conftest container image. For OpenShift Container Platform
the admission controller will assign UID and GID based on the
range defined for the OpenShift project / K8s namespace where
Starboard is installed.

Signed-off-by: Daniel Pacak <pacak.daniel@gmail.com>