### PR TITLE
poc: Audit configuration of other K8s objects

### DIFF
--- a/deploy/static/03-starboard-operator.clusterrole.yaml
+++ b/deploy/static/03-starboard-operator.clusterrole.yaml
@@ -11,6 +11,7 @@ rules:
       - pods
       - pods/log
       - replicationcontrollers
+      - services
     verbs:
       - get
       - list
@@ -53,6 +54,15 @@ rules:
       - replicasets
       - statefulsets
       - daemonsets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - roles
+      - rolebindings
     verbs:
       - get
       - list

--- a/pkg/cmd/installer.go
+++ b/pkg/cmd/installer.go
@@ -61,6 +61,7 @@ var (
 					"nodes",
 					"namespaces",
 					"pods",
+					"services",
 				},
 				Verbs: []string{
 					"list",

--- a/pkg/configauditreport/builder.go
+++ b/pkg/configauditreport/builder.go
@@ -66,14 +66,12 @@ func (s *ScanJobBuilder) Get() (*batchv1.Job, []*corev1.Secret, error) {
 		return nil, nil, err
 	}
 
-	podSpec, err := kube.GetPodSpec(s.object)
+	podSpecHash, err := kube.ComputeSpecHash(s.object)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	jobSpec.Tolerations = append(jobSpec.Tolerations, s.tolerations...)
-
-	podSpecHash := kube.ComputeHash(podSpec)
 
 	pluginConfigHash, err := s.plugin.GetConfigHash(s.pluginContext)
 	if err != nil {

--- a/pkg/kube/object.go
+++ b/pkg/kube/object.go
@@ -11,6 +11,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -48,6 +49,10 @@ const (
 	KindDaemonSet             Kind = "DaemonSet"
 	KindCronJob               Kind = "CronJob"
 	KindJob                   Kind = "Job"
+	KindService               Kind = "Service"
+	KindConfigMap             Kind = "ConfigMap"
+	KindRole                  Kind = "Role"
+	KindRoleBinding           Kind = "RoleBinding"
 )
 
 // IsBuiltInWorkload returns true if the specified v1.OwnerReference
@@ -128,6 +133,32 @@ func GetPartialObjectFromKindAndNamespacedName(kind Kind, name types.NamespacedN
 	}
 }
 
+// ComputeSpecHash computes hash of the specified K8s client.Object.
+// The hash is used to indicate whether the client.Object should be
+// rescanned or not by adding it as a label to an instance of security
+// report.
+// TODO Brainstorm how we compute hash for Services, ConfigMaps, and other objects.
+func ComputeSpecHash(obj client.Object) (string, error) {
+	switch t := obj.(type) {
+	case *corev1.Pod, *appsv1.Deployment, *appsv1.ReplicaSet, *corev1.ReplicationController, *appsv1.StatefulSet, *appsv1.DaemonSet, *batchv1beta1.CronJob, *batchv1.Job:
+		spec, err := GetPodSpec(obj)
+		if err != nil {
+			return "", err
+		}
+		return ComputeHash(spec), nil
+	case *corev1.Service:
+		return ComputeHash((obj.(*corev1.Service)).Spec), nil
+	case *corev1.ConfigMap:
+		return ComputeHash(obj), nil
+	case *rbacv1.Role:
+		return ComputeHash(obj), nil
+	case *rbacv1.RoleBinding:
+		return ComputeHash(obj), nil
+	default:
+		return "", fmt.Errorf("computing spec hash of unsupported object: %T", t)
+	}
+}
+
 // GetPodSpec returns v1.PodSpec from the specified Kubernetes
 // client.Object. Returns error if the given client.Object
 // is not a Kubernetes workload.
@@ -177,6 +208,14 @@ func (o *ObjectResolver) GetObjectFromPartialObject(ctx context.Context, workloa
 		obj = &batchv1beta1.CronJob{}
 	case KindJob:
 		obj = &batchv1.Job{}
+	case KindService:
+		obj = &corev1.Service{}
+	case KindConfigMap:
+		obj = &corev1.ConfigMap{}
+	case KindRole:
+		obj = &rbacv1.Role{}
+	case KindRoleBinding:
+		obj = &rbacv1.RoleBinding{}
 	default:
 		return nil, fmt.Errorf("unknown kind: %s", workload.Kind)
 	}

--- a/pkg/starboard/config.go
+++ b/pkg/starboard/config.go
@@ -13,6 +13,7 @@ import (
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	coordinationv1 "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -26,6 +27,7 @@ func NewScheme() *runtime.Scheme {
 	_ = appsv1.AddToScheme(scheme)
 	_ = batchv1.AddToScheme(scheme)
 	_ = batchv1beta1.AddToScheme(scheme)
+	_ = rbacv1.AddToScheme(scheme)
 	_ = v1alpha1.AddToScheme(scheme)
 	_ = coordinationv1.AddToScheme(scheme)
 	return scheme


### PR DESCRIPTION
## TODO

- [x] Services
- [x] ConfigMaps
- [x] Roles
- [x] RoleBindings
- [ ] ClusterRole
- [ ] ClusterRoleBindings
- [ ] CustomResourceDefinition

## Notes

- [ ] Deprecate `pod-spec-hash` label and introduce `resource-spec-hash`

Signed-off-by: Daniel Pacak <pacak.daniel@gmail.com>