### PR TITLE
[WIP] feat: using image digests (instead of tags) for vulnerability reports

### DIFF
--- a/pkg/kube/resources.go
+++ b/pkg/kube/resources.go
@@ -22,6 +22,22 @@ func GetContainerImagesFromPodSpec(spec corev1.PodSpec) ContainerImages {
 	return images
 }
 
+// GetContainerImageDigestsFromPodStatus returns a map of container names
+// to container images (image digests) from the specified v1.PodStatus's InitContainerStatuses, ContainerStatuses and EphemeralContainerStatuses.
+func GetContainerImageDigestsFromPodStatus(status corev1.PodStatus) ContainerImages {
+	images := ContainerImages{}
+	for _, container := range status.InitContainerStatuses {
+		images[container.Name] = container.ImageID
+	}
+	for _, container := range status.ContainerStatuses {
+		images[container.Name] = container.ImageID
+	}
+	for _, container := range status.EphemeralContainerStatuses {
+		images[container.Name] = container.ImageID
+	}
+	return images
+}
+
 // GetContainerImagesFromJob returns a map of container names
 // to container images from the specified v1.Job.
 // The mapping is encoded as JSON value of the AnnotationContainerImages

--- a/pkg/kube/resources_test.go
+++ b/pkg/kube/resources_test.go
@@ -31,6 +31,32 @@ func TestGetContainerImagesFromPodSpec(t *testing.T) {
 	}, images)
 }
 
+func TestGetContainerImageDigestsFromPodStatus(t *testing.T) {
+	images := kube.GetContainerImageDigestsFromPodStatus(corev1.PodStatus{
+		InitContainerStatuses: []corev1.ContainerStatus{
+			{
+				Name:    "busybox",
+				ImageID: "docker.io/library/busybox@sha256:be4684e4004560b2cd1f12148b7120b0ea69c385bcc9b12a637537a2c60f97fb",
+			},
+		},
+		ContainerStatuses: []corev1.ContainerStatus{
+			{
+				Name:    "nginx",
+				ImageID: "docker.io/library/nginx@sha256:d20aa6d1cae56fd17cd458f4807e0de462caf2336f0b70b5eeb69fcaaf30dd9c",
+			},
+			{
+				Name:    "wordpress",
+				ImageID: "docker.io/library/wordpress@sha256:69607dc78dda010e6708c6ced72c80563ad55b180286c66198b319bf0ee74173",
+			},
+		},
+	})
+	assert.Equal(t, kube.ContainerImages{
+		"busybox":   "docker.io/library/busybox@sha256:be4684e4004560b2cd1f12148b7120b0ea69c385bcc9b12a637537a2c60f97fb",
+		"nginx":     "docker.io/library/nginx@sha256:d20aa6d1cae56fd17cd458f4807e0de462caf2336f0b70b5eeb69fcaaf30dd9c",
+		"wordpress": "docker.io/library/wordpress@sha256:69607dc78dda010e6708c6ced72c80563ad55b180286c66198b319bf0ee74173",
+	}, images)
+}
+
 func TestGetContainerImagesFromJob(t *testing.T) {
 
 	t.Run("Should return error when annotation is not set", func(t *testing.T) {

--- a/pkg/vulnerabilityreport/scanner.go
+++ b/pkg/vulnerabilityreport/scanner.go
@@ -72,7 +72,11 @@ func (s *Scanner) Scan(ctx context.Context, workload kube.Object) ([]v1alpha1.Vu
 	if err != nil {
 		return nil, fmt.Errorf("getting Pod template: %w", err)
 	}
-
+	podsUnderConsideration, err := s.objectResolver.GetPodsUnderConsideration(ctx, owner)
+	if err != nil {
+		return nil, fmt.Errorf("fetching the pods under consideration: %w", err)
+	}
+	status := podsUnderConsideration[0].Status
 	klog.V(3).Infof("Scanning with options: %+v", s.opts)
 
 	credentials, err := s.getCredentials(ctx, spec, workload.Namespace)
@@ -80,7 +84,7 @@ func (s *Scanner) Scan(ctx context.Context, workload kube.Object) ([]v1alpha1.Vu
 		return nil, err
 	}
 
-	job, secrets, err := s.prepareScanJob(workload, spec, credentials)
+	job, secrets, err := s.prepareScanJob(workload, spec, status, credentials)
 	if err != nil {
 		return nil, fmt.Errorf("preparing scan job: %w", err)
 	}
@@ -115,7 +119,7 @@ func (s *Scanner) getCredentials(ctx context.Context, spec corev1.PodSpec, ns st
 	return kube.MapContainerNamesToDockerAuths(kube.GetContainerImagesFromPodSpec(spec), imagePullSecrets)
 }
 
-func (s *Scanner) prepareScanJob(workload kube.Object, spec corev1.PodSpec, credentials map[string]docker.Auth) (*batchv1.Job, []*corev1.Secret, error) {
+func (s *Scanner) prepareScanJob(workload kube.Object, spec corev1.PodSpec, status corev1.PodStatus, credentials map[string]docker.Auth) (*batchv1.Job, []*corev1.Secret, error) {
 	templateSpec, secrets, err := s.plugin.GetScanJobSpec(spec, credentials)
 	if err != nil {
 		return nil, nil, err
@@ -123,7 +127,7 @@ func (s *Scanner) prepareScanJob(workload kube.Object, spec corev1.PodSpec, cred
 
 	templateSpec.ServiceAccountName = starboard.ServiceAccountName
 
-	containerImagesAsJSON, err := kube.GetContainerImagesFromPodSpec(spec).AsJSON()
+	containerImageDigestsAsJSON, err := kube.GetContainerImageDigestsFromPodStatus(status).AsJSON()
 	if err != nil {
 		return nil, nil, err
 	}
@@ -138,7 +142,7 @@ func (s *Scanner) prepareScanJob(workload kube.Object, spec corev1.PodSpec, cred
 				starboard.LabelResourceNamespace: workload.Namespace,
 			},
 			Annotations: map[string]string{
-				starboard.AnnotationContainerImages: containerImagesAsJSON,
+				starboard.AnnotationContainerImages: containerImageDigestsAsJSON,
 			},
 		},
 		Spec: batchv1.JobSpec{


### PR DESCRIPTION
Signed-off-by: Yashvardhan Kukreja <yash.kukreja.98@gmail.com>

The way this PR is implemented is that it queries the pod in runtime and looks at the relevant's pod's `status.containerStatuses[*].ImageID` to identify the image digests being in use.
And starboard makes use of "ownerReferences" to identify which Pod to query as per the user-provided `starboard scan vulnerability <resource-type>/<resource-name>`.

Shedding more light to that:
- If the provided resource to be scanned is a Pod itself - For example, `starboard scan vuln.. nginx-pod` - starboard will fetch the details of that pod through controller-runtime and look into its `status.containerStatuses[*].ImageID` to identify the image digests.
- If the provided resource to be scanned is a Deployment/CronJob - For example, `starboard scan vuln...  deployment/nginx` - starboard will first of all figure out the immediate child replicaset/Job of that Deployment/CronJob respectively. And then, query only those Pods who have their ownerReference pointing to that replicaset/Job. And then, simply look at one of those Pods `status.containerStatuses[*].ImageID` (no need to look at the specs of all the pods under the replicaset/job) because all of those pods will have the same spec and hence, the same set of image digests. Hence, looking into `status.ContainerStatuses[*].ImageID` of any one child pod of the replicaset/Job would provide the relevant image digests in use.
- If the provided resource to be scanned is a ReplicaSet/DaemonSet/StatefulSet/Job - For example, `starboard scan vuln.. daemonset/sample-daemonset` - starboard will figure out the child pods of that ReplicaSet/DaemonSet/StatefulSet/Job via "ownerReference" and look at one of the fetched pods, and look at its `status.ContainerStatuses[*].ImageID` to figure out the image digests in use.

And hence, the figured out image digests will be fed to the scan job instead of image names with tags.

