### PR TITLE
refactor(trivy): Read config from starboard-trivy-config ConfigMap

### DIFF
--- a/deploy/helm/templates/config.yaml
+++ b/deploy/helm/templates/config.yaml
@@ -10,17 +10,6 @@ data:
   scanJob.annotations: {{ .Values.starboard.scanJobAnnotations | quote }}
   {{- if .Values.operator.vulnerabilityScannerEnabled }}
   vulnerabilityReports.scanner: {{ .Values.starboard.vulnerabilityReportsPlugin | quote }}
-  {{- if eq .Values.starboard.vulnerabilityReportsPlugin "Trivy" }}
-  trivy.imageRef: "{{ .Values.trivy.imageRef }}"
-  trivy.mode: "{{ .Values.trivy.mode }}"
-  {{- if eq .Values.trivy.mode "ClientServer" }}
-  trivy.serverURL: "{{ .Values.trivy.serverURL }}"
-  {{- end }}
-  trivy.httpProxy: "{{ .Values.trivy.httpProxy }}"
-  trivy.httpsProxy: "{{ .Values.trivy.httpsProxy }}"
-  trivy.noProxy: "{{ .Values.trivy.noProxy }}"
-  trivy.severity: "{{ .Values.trivy.severity }}"
-  {{- end }}
   {{- end }}
   {{- if .Values.operator.kubernetesBenchmarkEnabled }}
   kube-bench.imageRef: "{{ .Values.kubeBench.imageRef }}"
@@ -28,6 +17,32 @@ data:
   {{- if .Values.operator.configAuditScannerEnabled }}
   configAuditReports.scanner: {{ .Values.starboard.configAuditReportsPlugin | quote }}
   {{- end }}
+{{- if eq .Values.starboard.vulnerabilityReportsPlugin "Trivy" }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: starboard-trivy-config
+  labels:
+    {{- include "starboard-operator.labels" . | nindent 4 }}
+data:
+  trivy.imageRef: {{ .Values.trivy.imageRef | quote }}
+  trivy.mode: {{ .Values.trivy.mode | quote }}
+  trivy.httpProxy: "{{ .Values.trivy.httpProxy }}"
+  trivy.httpsProxy: "{{ .Values.trivy.httpsProxy }}"
+  trivy.noProxy: "{{ .Values.trivy.noProxy }}"
+  trivy.severity: "{{ .Values.trivy.severity }}"
+  {{- if eq .Values.trivy.mode "ClientServer" }}
+  trivy.serverURL: "{{ .Values.trivy.serverURL }}"
+  {{- end }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: starboard-trivy-config
+  labels:
+    {{- include "starboard-operator.labels" . | nindent 4 }}
+{{- end }}
 {{- if eq .Values.starboard.configAuditReportsPlugin "Conftest" }}
 ---
 apiVersion: v1

--- a/deploy/static/05-starboard-operator.config.yaml
+++ b/deploy/static/05-starboard-operator.config.yaml
@@ -7,11 +7,17 @@ metadata:
 data:
   vulnerabilityReports.scanner: Trivy
   configAuditReports.scanner: Polaris
+  kube-bench.imageRef: docker.io/aquasec/kube-bench:0.5.0
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: starboard-trivy-config
+  namespace: starboard-operator
+data:
   trivy.severity: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL
   trivy.imageRef: docker.io/aquasec/trivy:0.16.0
   trivy.mode: Standalone
-  trivy.serverURL: http://trivy-server.trivy-server:4954
-  kube-bench.imageRef: docker.io/aquasec/kube-bench:0.5.0
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -52,10 +52,10 @@ func NewRootCmd(buildInfo starboard.BuildInfo, args []string, outWriter io.Write
 	cf = genericclioptions.NewConfigFlags(true)
 
 	rootCmd.AddCommand(NewVersionCmd(buildInfo, outWriter))
-	rootCmd.AddCommand(NewInitCmd(cf))
+	rootCmd.AddCommand(NewInitCmd(buildInfo, cf))
 	rootCmd.AddCommand(NewScanCmd(buildInfo, cf))
 	rootCmd.AddCommand(NewGetCmd(buildInfo, cf, outWriter))
-	rootCmd.AddCommand(NewCleanupCmd(cf))
+	rootCmd.AddCommand(NewCleanupCmd(buildInfo, cf))
 	rootCmd.AddCommand(NewConfigCmd(cf, outWriter))
 
 	SetGlobalFlags(cf, rootCmd)

--- a/pkg/cmd/scan_configauditreports.go
+++ b/pkg/cmd/scan_configauditreports.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/aquasecurity/starboard/pkg/configauditreport"
 	"github.com/aquasecurity/starboard/pkg/plugin"
@@ -72,10 +71,6 @@ func ScanConfigAuditReports(buildInfo starboard.BuildInfo, cf *genericclioptions
 			GetConfigAuditPlugin()
 		if err != nil {
 			return err
-		}
-		err = plugin.Init(pluginContext)
-		if err != nil {
-			return fmt.Errorf("initializing %s plugin: %w", pluginContext.GetName(), err)
 		}
 		scanner := configauditreport.NewScanner(kubeClientset, kubeClient, plugin, pluginContext, config, opts)
 		report, err := scanner.Scan(ctx, workload)

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -140,6 +140,11 @@ func Start(ctx context.Context, buildInfo starboard.BuildInfo, operatorConfig et
 			return err
 		}
 
+		err = plugin.Init(pluginContext)
+		if err != nil {
+			return fmt.Errorf("initializing %s plugin: %w", pluginContext.GetName(), err)
+		}
+
 		if err = (&controller.VulnerabilityReportReconciler{
 			Logger:         ctrl.Log.WithName("reconciler").WithName("vulnerabilityreport"),
 			Config:         operatorConfig,

--- a/pkg/plugin/aqua/plugin.go
+++ b/pkg/plugin/aqua/plugin.go
@@ -32,6 +32,11 @@ func NewPlugin(
 	}
 }
 
+func (s *plugin) Init(_ starboard.PluginContext) error {
+	// Do nothing
+	return nil
+}
+
 func (s *plugin) GetScanJobSpec(ctx starboard.PluginContext, spec corev1.PodSpec, _ map[string]docker.Auth) (corev1.PodSpec, []*corev1.Secret, error) {
 	initContainerName := s.idGenerator.GenerateID()
 

--- a/pkg/plugin/factory.go
+++ b/pkg/plugin/factory.go
@@ -72,7 +72,7 @@ func (r *Resolver) GetVulnerabilityPlugin() (vulnerabilityreport.Plugin, starboa
 
 	switch scanner {
 	case starboard.Trivy:
-		return trivy.NewPlugin(ext.NewSystemClock(), ext.NewGoogleUUIDGenerator(), r.config), pluginContext, nil
+		return trivy.NewPlugin(ext.NewSystemClock(), ext.NewGoogleUUIDGenerator()), pluginContext, nil
 	case starboard.Aqua:
 		return aqua.NewPlugin(ext.NewGoogleUUIDGenerator(), r.buildInfo), pluginContext, nil
 	}

--- a/pkg/starboard/config.go
+++ b/pkg/starboard/config.go
@@ -72,10 +72,6 @@ func GetDefaultConfig() ConfigData {
 		keyVulnerabilityReportsScanner: string(Trivy),
 		keyConfigAuditReportsScanner:   string(Polaris),
 
-		"trivy.severity": "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL",
-		"trivy.imageRef": "docker.io/aquasec/trivy:0.16.0",
-		"trivy.mode":     "Standalone",
-
 		"kube-bench.imageRef":  "docker.io/aquasec/kube-bench:0.5.0",
 		"kube-hunter.imageRef": "docker.io/aquasec/kube-hunter:0.4.1",
 		"kube-hunter.quick":    "false",

--- a/pkg/starboard/plugin.go
+++ b/pkg/starboard/plugin.go
@@ -3,9 +3,10 @@ package starboard
 import (
 	"context"
 	"fmt"
+	"strings"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -48,6 +49,7 @@ type PluginContext interface {
 
 // GetPluginConfigMapName returns the name of a ConfigMap used to configure a plugin
 // with the given name.
+// TODO Rename to GetPluginConfigObjectName as this method is used to determine the name of ConfigMaps and Secrets.
 func GetPluginConfigMapName(pluginName string) string {
 	return "starboard-" + strings.ToLower(pluginName) + "-config"
 }

--- a/pkg/vulnerabilityreport/plugin.go
+++ b/pkg/vulnerabilityreport/plugin.go
@@ -13,6 +13,10 @@ import (
 // scanners.
 type Plugin interface {
 
+	// Init is a callback to initialize this plugin, e.g. ensure the default
+	// configuration.
+	Init(ctx starboard.PluginContext) error
+
 	// GetScanJobSpec describes the pod that will be created by Starboard when
 	// it schedules a Kubernetes job to scan the workload with the specified
 	// descriptor.


### PR DESCRIPTION
We started off with all config settings read from the starboard
ConfigMap and the starboard Secret. However, this does not scale
well with a number of plugins and configuration options.

This commit allows Triy plugin to read its settings from
the starboard-trivy-config ConfigMap and the starboard-trivy-config
Secret.

Signed-off-by: Daniel Pacak <pacak.daniel@gmail.com>