### PR TITLE
chore: chart app version

### DIFF
--- a/.github/workflows/publish-helm-chart.yaml
+++ b/.github/workflows/publish-helm-chart.yaml
@@ -4,6 +4,8 @@
 name: Publish Helm chart
 
 on:
+  tags:
+    - "v*"
   workflow_dispatch:
 env:
   HELM_REP: helm-charts
@@ -20,14 +22,17 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v1
         with:
-          version: v3.5.0
+          version: v3.6.0
       - name: Install chart-releaser
+        env:
+          VERSION: 1.2.1
         run: |
-          wget https://github.com/helm/chart-releaser/releases/download/v1.1.1/chart-releaser_1.1.1_linux_amd64.tar.gz
-          tar xzvf chart-releaser_1.1.1_linux_amd64.tar.gz cr
+          wget "https://github.com/helm/chart-releaser/releases/download/v${VERSION}/chart-releaser_${VERSION}_linux_amd64.tar.gz"
+          tar xzvf chart-releaser_${VERSION}_linux_amd64.tar.gz cr
       - name: Package helm chart
         run: |
-          ./cr package ${{ env.CHART_DIR }}
+          RELEASE=$(echo ${{ github.ref }} | sed -e "s#refs/tags/##g" | sed -e 's/^v//')
+          helm package --app-version=${RELEASE} --version=${RELEASE} ${{ env.CHART_DIR }} -d .cr-release-packages
       - name: Upload helm chart
         # Failed with upload the same version: https://github.com/helm/chart-releaser/issues/101
         continue-on-error: true


### PR DESCRIPTION
- Upgrade the helm chart with the release tag app.
- The helm chart will be the same version as the app.
 `helm package --app-version=${RELEASE} --version=${RELEASE}`