### PR TITLE
docs: Manual removal of installed crds

### DIFF
--- a/docs/operator/installation/helm.md
+++ b/docs/operator/installation/helm.md
@@ -69,6 +69,7 @@ You have to manually delete custom resource definitions created by the `helm ins
     kubectl delete crd configauditreports.aquasecurity.github.io
     kubectl delete crd ciskubebenchreports.aquasecurity.github.io
     kubectl delete crd kubehunterreports.aquasecurity.github.io
+    kubectl delete crd clusterconfigauditreports.aquasecurity.github.io
     ```
 
 [helm]: https://helm.sh/

--- a/docs/operator/installation/helm.md
+++ b/docs/operator/installation/helm.md
@@ -68,6 +68,7 @@ You have to manually delete custom resource definitions created by the `helm ins
     kubectl delete crd vulnerabilityreports.aquasecurity.github.io
     kubectl delete crd configauditreports.aquasecurity.github.io
     kubectl delete crd ciskubebenchreports.aquasecurity.github.io
+    kubectl delete crd kubehunterreports.aquasecurity.github.io
     ```
 
 [helm]: https://helm.sh/


### PR DESCRIPTION
A Helm installation with default values left crd `kubehunterreports.aquasecurity.github.io` on our system after going through the uninstall steps. We confirmed no other aquasecurity crd's were left.

This PR adds the missing crd to the uninstall documentation. It appears my editor also removed a trailing newline at the end of the file.