### PR TITLE
Introduce resource request/limit parameters for trivy pod 

### DIFF
--- a/deploy/helm/templates/config.yaml
+++ b/deploy/helm/templates/config.yaml
@@ -35,18 +35,25 @@ data:
   {{- if eq .Values.trivy.mode "ClientServer" }}
   trivy.serverURL: "{{ .Values.trivy.serverURL }}"
   {{- end }}
-  {{- if .Values.trivy.requestCPU }}
-  trivy.requestCPU: "{{ .Values.trivy.requestCPU }}"
+  {{- with .Values.trivy.resources }}
+    {{- with .request }}
+      {{- if .cpu }}
+  trivy.resources.request.cpu: {{ .cpu }}
+      {{- end }}
+      {{- if hasKey . "memory" }}
+  trivy.resources.request.memory: {{ .memory }}
+      {{- end }}
+    {{- end }}
+    {{- with .limit }}
+      {{- if .cpu }}
+  trivy.resources.limit.cpu: {{ .cpu }}
+      {{- end }}
+      {{- if .memory }}
+  trivy.resources.limit.memory: {{ .memory }}
+      {{- end }}
+    {{- end }}
   {{- end }}
-  {{- if .Values.trivy.requestMemory }}
-  trivy.requestMemory: "{{ .Values.trivy.requestMemory }}"
-  {{- end }}
-  {{- if .Values.trivy.limitCPU }}
-  trivy.limitCPU: "{{ .Values.trivy.limitCPU }}"
-  {{- end }}
-  {{- if .Values.trivy.limitCPU }}
-  trivy.limitMemory: "{{ .Values.trivy.limitMemory }}"
-  {{- end }}
+
 ---
 apiVersion: v1
 kind: Secret

--- a/deploy/helm/templates/config.yaml
+++ b/deploy/helm/templates/config.yaml
@@ -35,6 +35,18 @@ data:
   {{- if eq .Values.trivy.mode "ClientServer" }}
   trivy.serverURL: "{{ .Values.trivy.serverURL }}"
   {{- end }}
+  {{- if .Values.trivy.requestCPU }}
+  trivy.requestCPU: "{{ .Values.trivy.requestCPU }}"
+  {{- end }}
+  {{- if .Values.trivy.requestMemory }}
+  trivy.requestMemory: "{{ .Values.trivy.requestMemory }}"
+  {{- end }}
+  {{- if .Values.trivy.limitCPU }}
+  trivy.limitCPU: "{{ .Values.trivy.limitCPU }}"
+  {{- end }}
+  {{- if .Values.trivy.limitCPU }}
+  trivy.limitMemory: "{{ .Values.trivy.limitMemory }}"
+  {{- end }}
 ---
 apiVersion: v1
 kind: Secret

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -92,6 +92,14 @@ trivy:
   httpsProxy:
   noProxy:
   severity: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL
+  #k8s CPU request for the trivy pod
+  requestCPU:
+  #k8s memory request for the trivy pod
+  requestMemory:
+  #k8s CPU limit for the trivy pod
+  limitCPU:
+  #k8s memory limit for the trivy pod
+  limitMemory:
 
 kubeBench:
   imageRef: docker.io/aquasec/kube-bench:0.6.3

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -92,14 +92,14 @@ trivy:
   httpsProxy:
   noProxy:
   severity: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL
-  #k8s CPU request for the trivy pod
-  requestCPU:
-  #k8s memory request for the trivy pod
-  requestMemory:
-  #k8s CPU limit for the trivy pod
-  limitCPU:
-  #k8s memory limit for the trivy pod
-  limitMemory:
+#k8s resource requests and limits
+  resources:
+    request:
+      cpu: 100m
+      memory: 100M
+    limit:
+      cpu: 500m
+      memory: 500M
 
 kubeBench:
   imageRef: docker.io/aquasec/kube-bench:0.6.3

--- a/deploy/static/05-starboard-operator.config.yaml
+++ b/deploy/static/05-starboard-operator.config.yaml
@@ -18,6 +18,10 @@ data:
   trivy.severity: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL
   trivy.imageRef: docker.io/aquasec/trivy:0.16.0
   trivy.mode: Standalone
+  trivy.resources.request.cpu: 100m
+  trivy.resources.request.memory: 100M
+  trivy.resources.limit.cpu: 500M
+  trivy.resources.limit.memory: 500M
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/deploy/static/05-starboard-operator.config.yaml
+++ b/deploy/static/05-starboard-operator.config.yaml
@@ -20,7 +20,7 @@ data:
   trivy.mode: Standalone
   trivy.resources.request.cpu: 100m
   trivy.resources.request.memory: 100M
-  trivy.resources.limit.cpu: 500M
+  trivy.resources.limit.cpu: 500m
   trivy.resources.limit.memory: 500M
 ---
 apiVersion: v1

--- a/pkg/plugin/trivy/plugin.go
+++ b/pkg/plugin/trivy/plugin.go
@@ -143,7 +143,7 @@ func (c Config) setResourceLimit(configKey string, k8sResourceList *corev1.Resou
 	if value, found := c.Data[configKey]; found {
 		quantity, err := resource.ParseQuantity(value)
 		if err != nil {
-			return fmt.Errorf("Couldn't parse resource definition %s: %s %v", configKey, value, err)
+			return fmt.Errorf("parsing resource definition %s: %s %v", configKey, value, err)
 		}
 
 		(*k8sResourceList)[k8sResourceName] = quantity

--- a/pkg/plugin/trivy/plugin.go
+++ b/pkg/plugin/trivy/plugin.go
@@ -152,6 +152,11 @@ func (p *plugin) Init(ctx starboard.PluginContext) error {
 			keyTrivyImageRef: "docker.io/aquasec/trivy:0.16.0",
 			keyTrivySeverity: "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL",
 			keyTrivyMode:     string(Standalone),
+
+			keyTrivyResourcesRequestsCPU:    "100m",
+			keyTrivyResourcesRequestsMemory: "100M",
+			keyTrivyResourcesLimitMemory:    "500m",
+			keyTrivyResourcesLimitCPU:       "500M",
 		},
 	})
 }

--- a/pkg/plugin/trivy/plugin.go
+++ b/pkg/plugin/trivy/plugin.go
@@ -110,24 +110,45 @@ func (c Config) GetInsecureRegistries() map[string]bool {
 }
 
 //GetResourceRequirements creates k8s requires/limit fragments from the config
-func (c Config) GetResourceRequirements() corev1.ResourceRequirements {
+func (c Config) GetResourceRequirements() (corev1.ResourceRequirements, error) {
 	defaultResourceRequirements := corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{},
 		Limits:   corev1.ResourceList{},
 	}
 
-	c.setResourceLimit(keyTrivyResourcesRequestsCPU, &defaultResourceRequirements.Requests, corev1.ResourceCPU)
-	c.setResourceLimit(keyTrivyResourcesRequestsMemory, &defaultResourceRequirements.Requests, corev1.ResourceMemory)
-	c.setResourceLimit(keyTrivyResourcesLimitCPU, &defaultResourceRequirements.Limits, corev1.ResourceCPU)
-	c.setResourceLimit(keyTrivyResourcesLimitMemory, &defaultResourceRequirements.Limits, corev1.ResourceMemory)
+	err := c.setResourceLimit(keyTrivyResourcesRequestsCPU, &defaultResourceRequirements.Requests, corev1.ResourceCPU)
+	if err != nil {
+		return defaultResourceRequirements, err
+	}
 
-	return defaultResourceRequirements
+	err = c.setResourceLimit(keyTrivyResourcesRequestsMemory, &defaultResourceRequirements.Requests, corev1.ResourceMemory)
+	if err != nil {
+		return defaultResourceRequirements, err
+	}
+
+	err = c.setResourceLimit(keyTrivyResourcesLimitCPU, &defaultResourceRequirements.Limits, corev1.ResourceCPU)
+	if err != nil {
+		return defaultResourceRequirements, err
+	}
+
+	err = c.setResourceLimit(keyTrivyResourcesLimitMemory, &defaultResourceRequirements.Limits, corev1.ResourceMemory)
+	if err != nil {
+		return defaultResourceRequirements, err
+	}
+
+	return defaultResourceRequirements, nil
 }
 
-func (c Config) setResourceLimit(configKey string, k8sResourceList *corev1.ResourceList, k8sResourceName corev1.ResourceName) {
+func (c Config) setResourceLimit(configKey string, k8sResourceList *corev1.ResourceList, k8sResourceName corev1.ResourceName) error {
 	if value, found := c.Data[configKey]; found {
-		(*k8sResourceList)[k8sResourceName] = resource.MustParse(value)
+		quantity, err := resource.ParseQuantity(value)
+		if err != nil {
+			return fmt.Errorf("Couldn't parse resource definition %s: %s %v", configKey, value, err)
+		}
+
+		(*k8sResourceList)[k8sResourceName] = quantity
 	}
+	return nil
 }
 
 // NewPlugin constructs a new vulnerabilityreport.Plugin, which is using an
@@ -155,8 +176,8 @@ func (p *plugin) Init(ctx starboard.PluginContext) error {
 
 			keyTrivyResourcesRequestsCPU:    "100m",
 			keyTrivyResourcesRequestsMemory: "100M",
-			keyTrivyResourcesLimitMemory:    "500m",
-			keyTrivyResourcesLimitCPU:       "500M",
+			keyTrivyResourcesLimitCPU:       "500m",
+			keyTrivyResourcesLimitMemory:    "500M",
 		},
 	})
 }
@@ -228,6 +249,11 @@ func (p *plugin) getPodSpecForStandaloneMode(config Config, spec corev1.PodSpec,
 
 	trivyConfigName := starboard.GetPluginConfigMapName(Plugin)
 
+	requirements, err := config.GetResourceRequirements()
+	if err != nil {
+		return corev1.PodSpec{}, nil, err
+	}
+
 	initContainer := corev1.Container{
 		Name:                     p.idGenerator.GenerateID(),
 		Image:                    trivyImageRef,
@@ -291,7 +317,7 @@ func (p *plugin) getPodSpecForStandaloneMode(config Config, spec corev1.PodSpec,
 			"--cache-dir",
 			"/var/lib/trivy",
 		},
-		Resources: config.GetResourceRequirements(),
+		Resources: requirements,
 		VolumeMounts: []corev1.VolumeMount{
 			{
 				Name:      sharedVolumeName,
@@ -474,6 +500,11 @@ func (p *plugin) getPodSpecForStandaloneMode(config Config, spec corev1.PodSpec,
 			return corev1.PodSpec{}, nil, err
 		}
 
+		resourceRequirements, err := config.GetResourceRequirements()
+		if err != nil {
+			return corev1.PodSpec{}, nil, err
+		}
+
 		containers = append(containers, corev1.Container{
 			Name:                     c.Name,
 			Image:                    trivyImageRef,
@@ -492,7 +523,7 @@ func (p *plugin) getPodSpecForStandaloneMode(config Config, spec corev1.PodSpec,
 				"json",
 				c.Image,
 			},
-			Resources:    config.GetResourceRequirements(),
+			Resources:    resourceRequirements,
 			VolumeMounts: volumeMounts,
 			SecurityContext: &corev1.SecurityContext{
 				Privileged:               pointer.BoolPtr(false),
@@ -739,6 +770,11 @@ func (p *plugin) getPodSpecForClientServerMode(config Config, spec corev1.PodSpe
 			})
 		}
 
+		requirements, err := config.GetResourceRequirements()
+		if err != nil {
+			return corev1.PodSpec{}, nil, err
+		}
+
 		containers = append(containers, corev1.Container{
 			Name:                     container.Name,
 			Image:                    trivyImageRef,
@@ -758,7 +794,7 @@ func (p *plugin) getPodSpecForClientServerMode(config Config, spec corev1.PodSpe
 				container.Image,
 			},
 			VolumeMounts: volumeMounts,
-			Resources:    config.GetResourceRequirements(),
+			Resources:    requirements,
 		})
 	}
 

--- a/pkg/plugin/trivy/plugin_test.go
+++ b/pkg/plugin/trivy/plugin_test.go
@@ -121,27 +121,21 @@ func TestConfig_GetResourceResourceRequirements(t *testing.T) {
 		expectedRequirements corev1.ResourceRequirements
 	}{
 		{
-			name:       "Should return default requirements",
+			name:       "Should return empty requirements by default",
 			configData: trivy.Config{PluginConfig: starboard.PluginConfig{}},
 			expectedRequirements: corev1.ResourceRequirements{
-				Requests: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("100m"),
-					corev1.ResourceMemory: resource.MustParse("100M"),
-				},
-				Limits: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("500m"),
-					corev1.ResourceMemory: resource.MustParse("500M"),
-				},
+				Requests: corev1.ResourceList{},
+				Limits:   corev1.ResourceList{},
 			},
 		},
 		{
 			name: "Should return configured resource requirement",
 			configData: trivy.Config{PluginConfig: starboard.PluginConfig{
 				Data: map[string]string{
-					"trivy.requestCPU":    "800m",
-					"trivy.requestMemory": "200M",
-					"trivy.limitCPU":      "600m",
-					"trivy.limitMemory":   "700M",
+					"trivy.resources.request.cpu":    "800m",
+					"trivy.resources.request.memory": "200M",
+					"trivy.resources.limit.cpu":      "600m",
+					"trivy.resources.limit.memory":   "700M",
 				},
 			}},
 			expectedRequirements: corev1.ResourceRequirements{
@@ -152,24 +146,6 @@ func TestConfig_GetResourceResourceRequirements(t *testing.T) {
 				Limits: corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("600m"),
 					corev1.ResourceMemory: resource.MustParse("700M"),
-				},
-			},
-		},
-		{
-			name: "Should return default limits or configured if set",
-			configData: trivy.Config{PluginConfig: starboard.PluginConfig{
-				Data: map[string]string{
-					"trivy.requestMemory": "200M",
-				},
-			}},
-			expectedRequirements: corev1.ResourceRequirements{
-				Requests: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("100m"),
-					corev1.ResourceMemory: resource.MustParse("200M"),
-				},
-				Limits: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("500m"),
-					corev1.ResourceMemory: resource.MustParse("500M"),
 				},
 			},
 		},

--- a/pkg/plugin/trivy/plugin_test.go
+++ b/pkg/plugin/trivy/plugin_test.go
@@ -162,7 +162,7 @@ func TestConfig_GetResourceRequirements(t *testing.T) {
 					"trivy.resources.limit.memory":   "700M",
 				},
 			}},
-			expectedError: "Couldn't parse resource definition trivy.resources.request.cpu: roughly 100 quantities must match the regular expression '^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'",
+			expectedError: "parsing resource definition trivy.resources.request.cpu: roughly 100 quantities must match the regular expression '^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'",
 			expectedRequirements: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("800m"),

--- a/pkg/plugin/trivy/plugin_test.go
+++ b/pkg/plugin/trivy/plugin_test.go
@@ -114,7 +114,7 @@ func TestConfig_GetMode(t *testing.T) {
 	}
 }
 
-func TestConfig_GetResourceResourceRequirements(t *testing.T) {
+func TestConfig_GetResourceRequirements(t *testing.T) {
 	testCases := []struct {
 		name                 string
 		configData           trivy.Config

--- a/pkg/plugin/trivy/plugin_test.go
+++ b/pkg/plugin/trivy/plugin_test.go
@@ -253,6 +253,11 @@ func TestScanner_GetScanJobSpec(t *testing.T) {
 			config: map[string]string{
 				"trivy.imageRef": "docker.io/aquasec/trivy:0.14.0",
 				"trivy.mode":     string(trivy.Standalone),
+
+				"trivy.resources.request.cpu":    "100m",
+				"trivy.resources.request.memory": "100M",
+				"trivy.resources.limit.cpu":      "500m",
+				"trivy.resources.limit.memory":   "500M",
 			},
 			workloadSpec: corev1.PodSpec{
 				Containers: []corev1.Container{
@@ -497,6 +502,11 @@ func TestScanner_GetScanJobSpec(t *testing.T) {
 				"trivy.imageRef":                     "docker.io/aquasec/trivy:0.14.0",
 				"trivy.mode":                         string(trivy.Standalone),
 				"trivy.insecureRegistry.pocRegistry": "poc.myregistry.harbor.com.pl",
+
+				"trivy.resources.request.cpu":    "100m",
+				"trivy.resources.request.memory": "100M",
+				"trivy.resources.limit.cpu":      "500m",
+				"trivy.resources.limit.memory":   "500M",
 			},
 			workloadSpec: corev1.PodSpec{
 				Containers: []corev1.Container{
@@ -748,6 +758,10 @@ CVE-2018-14618
 
 # No impact in our settings
 CVE-2019-1543`,
+				"trivy.resources.request.cpu":    "100m",
+				"trivy.resources.request.memory": "100M",
+				"trivy.resources.limit.cpu":      "500m",
+				"trivy.resources.limit.memory":   "500M",
 			},
 			workloadSpec: corev1.PodSpec{
 				Containers: []corev1.Container{
@@ -1017,6 +1031,10 @@ CVE-2019-1543`,
 				"trivy.imageRef":  "docker.io/aquasec/trivy:0.14.0",
 				"trivy.mode":      string(trivy.ClientServer),
 				"trivy.serverURL": "http://trivy.trivy:4954",
+				"trivy.resources.request.cpu":    "100m",
+				"trivy.resources.request.memory": "100M",
+				"trivy.resources.limit.cpu":      "500m",
+				"trivy.resources.limit.memory":   "500M",
 			},
 			workloadSpec: corev1.PodSpec{
 				Containers: []corev1.Container{
@@ -1190,6 +1208,10 @@ CVE-2019-1543`,
 				"trivy.mode":                         string(trivy.ClientServer),
 				"trivy.serverURL":                    "http://trivy.trivy:4954",
 				"trivy.insecureRegistry.pocRegistry": "poc.myregistry.harbor.com.pl",
+				"trivy.resources.request.cpu":    "100m",
+				"trivy.resources.request.memory": "100M",
+				"trivy.resources.limit.cpu":      "500m",
+				"trivy.resources.limit.memory":   "500M",
 			},
 			workloadSpec: corev1.PodSpec{
 				Containers: []corev1.Container{
@@ -1371,6 +1393,10 @@ CVE-2018-14618
 
 # No impact in our settings
 CVE-2019-1543`,
+				"trivy.resources.request.cpu":    "100m",
+				"trivy.resources.request.memory": "100M",
+				"trivy.resources.limit.cpu":      "500m",
+				"trivy.resources.limit.memory":   "500M",
 			},
 			workloadSpec: corev1.PodSpec{
 				Containers: []corev1.Container{


### PR DESCRIPTION
This PR solves the problem reported in #572: with for new configuration values the resource/limit requirements of the trivy pod can be adjusted.

Defaults are added to the Helm charts and k8s resources:

```
#k8s resource requests and limits
  resources:
    request:
      cpu: 100m
      memory: 100M
    limit:
      cpu: 500m
      memory: 500M
```

But configmap of existing custom instances should be updated to use limits as before.  