### PR TITLE
Add Registry Mirrors to Trivy

### DIFF
--- a/docs/integrations/vulnerability-scanners/trivy.md
+++ b/docs/integrations/vulnerability-scanners/trivy.md
@@ -92,8 +92,7 @@ EOF
 | `trivy.serverURL`                 | N/A                                | The endpoint URL of the Trivy server. Required in `ClientServer` mode. |
 | `trivy.serverTokenHeader`         | `Trivy-Token`                      | The name of the HTTP header to send the authentication token to Trivy server. Only application in `ClientServer` mode when `trivy.serverToken` is specified. |
 | `trivy.insecureRegistry.<id>`     | N/A                                | The registry to which insecure connections are allowed. There can be multiple registries with different registry `<id>`. |
-| `trivy.mirrors.registry.<id>`     | N/A                                | A registry for which a mirror should be used to get an image. For the mirror url `trivy.mirrors.mirror.<id>` with the matching `<id>`. For each entry there must be a corresponding `trivy.mirrors.mirror.<id>` entry. There can be multiple registries with different registry `<id>`. |
-| `trivy.mirrors.mirror.<id>`       | N/A                                | The mirror for the registry with `<id>`. |
+| `trivy.registry.mirror.<registry>`| N/A                                | Mirror for the registry `<registry>`, e.g. `trivy.registry.mirror.index.docker.io: mirror.io` would use `mirror.io` to get images originated from `index.docker.io` |
 | `trivy.httpProxy`                 | N/A                                | The HTTP proxy used by Trivy to download the vulnerabilities database from GitHub. |
 | `trivy.httpsProxy`                | N/A                                | The HTTPS proxy used by Trivy to download the vulnerabilities database from GitHub. |
 | `trivy.noProxy`                   | N/A                                | A comma separated list of IPs and domain names that are not subject to proxy settings. |

--- a/docs/integrations/vulnerability-scanners/trivy.md
+++ b/docs/integrations/vulnerability-scanners/trivy.md
@@ -92,6 +92,8 @@ EOF
 | `trivy.serverURL`                 | N/A                                | The endpoint URL of the Trivy server. Required in `ClientServer` mode. |
 | `trivy.serverTokenHeader`         | `Trivy-Token`                      | The name of the HTTP header to send the authentication token to Trivy server. Only application in `ClientServer` mode when `trivy.serverToken` is specified. |
 | `trivy.insecureRegistry.<id>`     | N/A                                | The registry to which insecure connections are allowed. There can be multiple registries with different registry `<id>`. |
+| `trivy.mirrors.registry.<id>`     | N/A                                | A registry for which a mirror should be used to get an image. For the mirror url `trivy.mirrors.mirror.<id>` with the matching `<id>`. For each entry there must be a corresponding `trivy.mirrors.mirror.<id>` entry. There can be multiple registries with different registry `<id>`. |
+| `trivy.mirrors.mirror.<id>`       | N/A                                | The mirror for the registry with `<id>`. |
 | `trivy.httpProxy`                 | N/A                                | The HTTP proxy used by Trivy to download the vulnerabilities database from GitHub. |
 | `trivy.httpsProxy`                | N/A                                | The HTTPS proxy used by Trivy to download the vulnerabilities database from GitHub. |
 | `trivy.noProxy`                   | N/A                                | A comma separated list of IPs and domain names that are not subject to proxy settings. |


### PR DESCRIPTION
This patch adds the option to use mirrors for the docker registries in trivy.
This way it is possible to download the images from self-hosted mirrors instead
of e.g. index.docker.io. This has some benefits, like not being hit by download
restrictions.

I tried to also add this new Feature to the docs and I also wrote unit tests for it.

In the contributing guidelines is mentioned that for every PR there should also be a issue, but when generating a new issue of kind feature request, I am redirected to the discussion. So I skipped creating an issue for this, but I can do it afterwards, if necessary. For now I will point to the already existing discussion #260. 