### PR TITLE
fix: Handle nil pod in get pod by job

### DIFF
--- a/pkg/kube/logs.go
+++ b/pkg/kube/logs.go
@@ -31,6 +31,9 @@ func (r *logsReader) GetLogsByJobAndContainerName(ctx context.Context, job *batc
 	if err != nil {
 		return nil, fmt.Errorf("getting pod controllered by job: %q: %w", job.Namespace+"/"+job.Name, err)
 	}
+	if pod != nil {
+		return nil, fmt.Errorf("getting pod controlled by job: %q: pod not found", job.Namespace+"/"+job.Name)
+	}
 
 	return r.clientset.CoreV1().Pods(pod.Namespace).
 		GetLogs(pod.Name, &corev1.PodLogOptions{

--- a/pkg/kube/logs.go
+++ b/pkg/kube/logs.go
@@ -31,7 +31,7 @@ func (r *logsReader) GetLogsByJobAndContainerName(ctx context.Context, job *batc
 	if err != nil {
 		return nil, fmt.Errorf("getting pod controllered by job: %q: %w", job.Namespace+"/"+job.Name, err)
 	}
-	if pod != nil {
+	if pod == nil {
 		return nil, fmt.Errorf("getting pod controlled by job: %q: pod not found", job.Namespace+"/"+job.Name)
 	}
 


### PR DESCRIPTION
related to #627, but there are probably more to it. this is as far as I can replicate the problem at the moment, though the [original issue using previous version of starboard](https://github.com/aquasecurity/starboard/issues/627#issue-928389840) might have different cause as log also shows `apimachinery` panic handler.
```
2021-09-05T13:09:11.687Z    INFO    controller-runtime.manager.controller.cronjob    Starting workers    {"reconciler group": "batch", "reconciler kind": "CronJob", "worker count": 1}
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1303d09]
goroutine 547 [running[]:
github.com/aquasecurity/starboard/pkg/kube.(*logsReader).GetLogsByJobAndContainerName(0xc0004a5b20, {0x19b9698, 0xc000539800}, 0xc000471400, {0xc0003aa5ba, 0x5})
    /home/ronaudinho/spaghetti/ronaudinho/starboard/pkg/kube/logs.go:39 +0x129
github.com/aquasecurity/starboard/pkg/operator/controller.(*VulnerabilityReportReconciler).processCompleteScanJob(0xc000474280, {0x19b9698, 0xc000539800}, 0xc000471400)
    /home/ronaudinho/spaghetti/ronaudinho/starboard/pkg/operator/controller/vulnerabilityreport.go:384 +0x9d7
github.com/aquasecurity/starboard/pkg/operator/controller.(*VulnerabilityReportReconciler).reconcileJobs.func1({0x19b9698, 0xc000539800}, {{{0xc0004d33e0, 0x12}, {0xc0000baae0, 0x22}}})
    /home/ronaudinho/spaghetti/ronaudinho/starboard/pkg/operator/controller/vulnerabilityreport.go:331 +0x46e
sigs.k8s.io/controller-runtime/pkg/reconcile.Func.Reconcile(0x19b95f0, {0x19b9698, 0xc000539800}, {{{0xc0004d33e0, 0x16a4cc0}, {0xc0000baae0, 0xc0006b6080}}})
    /home/ronaudinho/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.9.6/pkg/reconcile/reconcile.go:102 +0x43
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc0003ac6e0, {0x19b95f0, 0xc000115540}, {0x1630580, 0xc0004287e0})
    /home/ronaudinho/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.9.6/pkg/internal/controller/controller.go:298 +0x303
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc0003ac6e0, {0x19b95f0, 0xc000115540})
    /home/ronaudinho/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.9.6/pkg/internal/controller/controller.go:253 +0x205
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2()
    /home/ronaudinho/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.9.6/pkg/internal/controller/controller.go:214 +0x85
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2
    /home/ronaudinho/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.9.6/pkg/internal/controller/controller.go:210 +0x354
```

p.s. still really can't figure out how to replicate in cluster, as this was achieved by setting `pod = nil` before return in https://github.com/aquasecurity/starboard/blob/00705edf87afced7ba6c406c3f3128d0e20316a6/pkg/kube/logs.go#L30-L39