### PR TITLE
feat(cli): Resolve report owners to be consistent with operator

### DIFF
--- a/itest/starboard/suite_test.go
+++ b/itest/starboard/suite_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/aquasecurity/starboard/pkg/kube"
 	"github.com/aquasecurity/starboard/pkg/starboard"
 	corev1 "k8s.io/api/core/v1"
 	apiextensions "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1"
@@ -20,6 +21,7 @@ import (
 var (
 	kubeClient             client.Client
 	apiextensionsClientset apiextensions.ApiextensionsV1beta1Interface
+	objectResolver         *kube.ObjectResolver
 )
 
 var (
@@ -99,6 +101,10 @@ var _ = BeforeSuite(func() {
 		Scheme: starboard.NewScheme(),
 	})
 	Expect(err).ToNot(HaveOccurred())
+
+	objectResolver = &kube.ObjectResolver{
+		Client: kubeClient,
+	}
 
 	apiextensionsClientset, err = apiextensions.NewForConfig(config)
 	Expect(err).ToNot(HaveOccurred())

--- a/pkg/configauditreport/scanner.go
+++ b/pkg/configauditreport/scanner.go
@@ -45,11 +45,16 @@ func NewScanner(
 	}
 }
 
-func (s *Scanner) Scan(ctx context.Context, obj kube.Object) (*ReportBuilder, error) {
-	if !s.plugin.SupportsKind(obj.Kind) {
-		return nil, fmt.Errorf("kind %s is not supported by %s plugin", obj.Kind, s.pluginContext.GetName())
+func (s *Scanner) Scan(ctx context.Context, partial kube.Object) (*ReportBuilder, error) {
+	if !s.plugin.SupportsKind(partial.Kind) {
+		return nil, fmt.Errorf("kind %s is not supported by %s plugin", partial.Kind, s.pluginContext.GetName())
 	}
-	owner, err := s.objectResolver.GetObjectFromPartialObject(ctx, obj)
+	obj, err := s.objectResolver.GetObjectFromPartialObject(ctx, partial)
+	if err != nil {
+		return nil, err
+	}
+
+	owner, err := s.objectResolver.ReportOwner(ctx, obj)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/vulnerabilityreport/scanner.go
+++ b/pkg/vulnerabilityreport/scanner.go
@@ -67,10 +67,16 @@ func NewScanner(
 func (s *Scanner) Scan(ctx context.Context, workload kube.Object) ([]v1alpha1.VulnerabilityReport, error) {
 	klog.V(3).Infof("Getting Pod template for workload: %v", workload)
 
-	owner, err := s.objectResolver.GetObjectFromPartialObject(ctx, workload)
+	workloadObj, err := s.objectResolver.GetObjectFromPartialObject(ctx, workload)
 	if err != nil {
 		return nil, fmt.Errorf("resolving object: %w", err)
 	}
+
+	owner, err := s.objectResolver.ReportOwner(ctx, workloadObj)
+	if err != nil {
+		return nil, err
+	}
+
 	spec, err := kube.GetPodSpec(owner)
 	if err != nil {
 		return nil, fmt.Errorf("getting Pod template: %w", err)


### PR DESCRIPTION
feat(cli): Resolve report owners to be consistent with operator

Starboard CLI was not consistent with Starboard Operator
when it comes to assigning VulnerabilityReports and ConfigAuditReports
to K8s workloads. For example, the report generated by the following
command was controlled by the nginx Deployment, whereas the Operator
would associate it with the active ReplicaSet (aka current revision).

    starboard scan vulnerabilityreports deploy/nginx

With this patch Starboard CLI will resolve the current revision of
a Deployment and use it as the owner of VulnerabilityReport and
ConfigAuditReport instances.

Signed-off-by: Daniel Pacak <pacak.daniel@gmail.com>