### PR TITLE
fix: panic when image pull secret cannot be parsed

### DIFF
--- a/pkg/docker/config.go
+++ b/pkg/docker/config.go
@@ -29,6 +29,9 @@ func (v *BasicAuth) Decode() (string, string, error) {
 		return "", "", err
 	}
 	split := strings.Split(string(bytes), ":")
+	if len(split) != 2 {
+		return "", "", fmt.Errorf("expected username and password concatenated with a colon (:)")
+	}
 	return split[0], split[1], nil
 }
 

--- a/pkg/docker/config_test.go
+++ b/pkg/docker/config_test.go
@@ -82,6 +82,17 @@ func TestConfig_Read(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Should return error when auth is not username and password concatenated with a colon",
+			givenJSON: `{
+							"auths": {
+								"my-registry.domain.io": {
+									"auth": "b25seXVzZXJuYW1l"
+								}
+							}
+						}`,
+			expectedError: errors.New("expected username and password concatenated with a colon (:)"),
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/kube/secrets.go
+++ b/pkg/kube/secrets.go
@@ -77,7 +77,7 @@ func MapDockerRegistryServersToAuths(imagePullSecrets []corev1.Secret) (map[stri
 		dockerConfig := &docker.Config{}
 		err := dockerConfig.Read(data)
 		if err != nil {
-			return nil, fmt.Errorf("reading content of %s: %w", corev1.DockerConfigJsonKey, err)
+			return nil, fmt.Errorf("reading %s field of %q secret: %w", corev1.DockerConfigJsonKey, secret.Namespace+"/"+secret.Name, err)
 		}
 		for authKey, auth := range dockerConfig.Auths {
 			server, err := docker.GetServerFromDockerAuthKey(authKey)


### PR DESCRIPTION
Indicate which secret cannot be parsed and why:

    error: reading .dockerconfigjson field of "default/regcred" secret: expected
    username and password concatenated with a colon (:)

Resolves: #751

Signed-off-by: Daniel Pacak <pacak.daniel@gmail.com>