### PR TITLE
feat(helm): Add PodSecurityPolicy creation

### DIFF
--- a/deploy/helm/templates/psp.yaml
+++ b/deploy/helm/templates/psp.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.podSecurityPolicy.create -}}
+---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ include "starboard-operator.fullname" . }}
+  labels:
+    {{- include "starboard-operator.labels" . | nindent 4 }}
+spec:
+  allowPrivilegeEscalation: false
+  fsGroup:
+    ranges:
+      - max: 65535
+        min: 1
+    rule: MustRunAs
+  requiredDropCapabilities:
+    - ALL
+  runAsGroup:
+    ranges:
+      - max: 65535
+        min: 1
+    rule: MustRunAs
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    ranges:
+      - max: 65535
+        min: 1
+    rule: MustRunAs
+  volumes:
+    - configMap
+    - emptyDir
+    - projected
+    - secret
+    - downwardAPI
+    - persistentVolumeClaim
+{{- end}}

--- a/deploy/helm/templates/rbac.yaml
+++ b/deploy/helm/templates/rbac.yaml
@@ -139,6 +139,16 @@ rules:
       - get
       - update
   {{- end }}
+  {{- if .Values.podSecurityPolicy.create }}
+  - apiGroups:
+      - extensions
+    resourceNames:
+      - {{ include "starboard-operator.fullname" . }}
+    resources:
+      - podsecuritypolicies
+    verbs:
+      - use
+  {{- end}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ $conditionalClusterPrefix }}RoleBinding

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -404,6 +404,9 @@ podAnnotations: {}
 podSecurityContext: {}
   # fsGroup: 2000
 
+podSecurityPolicy:
+  create: false
+
 securityContext:
   privileged: false
   allowPrivilegeEscalation: false

--- a/pkg/plugin/trivy/plugin.go
+++ b/pkg/plugin/trivy/plugin.go
@@ -550,6 +550,7 @@ func (p *plugin) getPodSpecForStandaloneMode(ctx starboard.PluginContext, config
 					Drop: []corev1.Capability{"all"},
 				},
 				ReadOnlyRootFilesystem: pointer.BoolPtr(true),
+				RunAsNonRoot: pointer.BoolPtr(false),
 			},
 		})
 	}


### PR DESCRIPTION
Add option to create a PodSecurityPolicy to allow the Trivy scanner to run within a cluster using PSPs. 
It is the minimal possible to allow the scanner pods to run as root, and fix the "*container has runAsNonRoot and image will run as root*" error when the default PSP restricts it.
Related to #290. 

I've set the name to start with `00` as there seems to be nothing set in the `securityContext` of the Trivy scanners to actually specify that they will run as root. This makes them use the alphabetically first PSP that allows the Pod spec to run, which in our case is the default restrictive one that allows the Pod but not the image.

I don't know where or how to change the spec of the Trivy scanners created by the operator so I'm focusing on what I used to make it run.