### PR TITLE
fix: scan images from private registries

### DIFF
--- a/pkg/operator/controller/vulnerabilityreport.go
+++ b/pkg/operator/controller/vulnerabilityreport.go
@@ -231,12 +231,13 @@ func (r *VulnerabilityReportReconciler) submitScanJob(ctx context.Context, owner
 		Get()
 
 	for _, secret := range secrets {
-		err := r.Client.Create(ctx, secret)
+		secret.Namespace = r.PluginContext.GetNamespace()
+		err = r.Client.Create(ctx, secret)
 		if err != nil {
 			if errors.IsAlreadyExists(err) {
 				return nil
 			}
-			return fmt.Errorf("creating secret: %w", err)
+			return fmt.Errorf("creating secret used by scan job failed: %s: %w", secret.Namespace+"/"+secret.Name, err)
 		}
 	}
 
@@ -246,7 +247,7 @@ func (r *VulnerabilityReportReconciler) submitScanJob(ctx context.Context, owner
 			// TODO Delete secrets that were created in the previous step. Alternatively we can delete them on schedule.
 			return nil
 		}
-		return fmt.Errorf("creating job: %w", err)
+		return fmt.Errorf("creating scan job failed: %s: %w", scanJob.Namespace+"/"+scanJob.Name, err)
 	}
 
 	for _, secret := range secrets {
@@ -256,7 +257,7 @@ func (r *VulnerabilityReportReconciler) submitScanJob(ctx context.Context, owner
 		}
 		err := r.Client.Update(ctx, secret)
 		if err != nil {
-			return fmt.Errorf("updating secret: %w", err)
+			return fmt.Errorf("setting owner reference of secret used by scan job failed: %s: %w", secret.Namespace+"/"+secret.Name, err)
 		}
 	}
 


### PR DESCRIPTION
This patch is solving a regression where we did not set
a namespace for secrets that are referred to by vulnerability
scan jobs.

Resolves: #835

Signed-off-by: Daniel Pacak <pacak.daniel@gmail.com>