### PR TITLE
feat(vulnrebilityreports) Only show the latest vulnrebilityreports from a deployment

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,7 @@ These guidelines will help you get started with the Starboard project.
 ## Build Binaries
 
 | Binary                   | Image                                          | Description                                                   |
-| ------------------------ | ---------------------------------------------- |  ------------------------------------------------------------ |
+| ------------------------ | ---------------------------------------------- | ------------------------------------------------------------- |
 | `starboard`              | `docker.io/aquasec/starboard:dev`              | Starboard command-line interface                              |
 | `starboard-operator`     | `docker.io/aquasec/starboard-operator:dev`     | Starboard Operator                                            |
 | `starboard-scanner-aqua` | `docker.io/aquasec/starboard-scanner-aqua:dev` | Starboard plugin to integrate with Aqua vulnerability scanner |
@@ -237,6 +237,7 @@ basic development workflow. For other install modes see [Operator Multitenancy w
      OPERATOR_LOG_DEV_MODE=true \
      OPERATOR_CIS_KUBERNETES_BENCHMARK_ENABLED=true \
      OPERATOR_VULNERABILITY_SCANNER_ENABLED=true \
+     OPERATOR_VULNERABILITY_SCANNER_SCAN_ONLY_CURRENT_REVISIONS=false \
      OPERATOR_CONFIG_AUDIT_SCANNER_ENABLED=true \
      OPERATOR_BATCH_DELETE_LIMIT=3 \
      OPERATOR_BATCH_DELETE_DELAY="30s" \

--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -77,6 +77,8 @@ spec:
               value: {{ .Values.operator.vulnerabilityScannerEnabled | quote }}
             - name: OPERATOR_CONFIG_AUDIT_SCANNER_ENABLED
               value: {{ .Values.operator.configAuditScannerEnabled | quote }}
+            - name: OPERATOR_VULNERABILITY_SCANNER_SCAN_ONLY_CURRENT_REVISIONS
+              value: {{ .Values.operator.vulnerabilityScannerScanOnlyCurrentRevisions | quote }}
             {{- if gt (int .Values.operator.replicas) 1 }}
             - name: OPERATOR_LEADER_ELECTION_ENABLED
               value: "true"

--- a/deploy/helm/templates/rbac.yaml
+++ b/deploy/helm/templates/rbac.yaml
@@ -76,6 +76,7 @@ rules:
       - replicasets
       - statefulsets
       - daemonsets
+      - deployments
     verbs:
       - get
       - list

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -41,6 +41,8 @@ operator:
   kubernetesBenchmarkEnabled: true
   # batchDeleteLimit the maximum number of config audit reports deleted by the operator when the plugin's config has changed.
   batchDeleteLimit: 10
+  # vulnerabilityScannerScanOnlyCurrentRevisions the flag to only create vulnerability scans on the current revision of a deployment.
+  vulnerabilityScannerScanOnlyCurrentRevisions: false
   # batchDeleteDelay the duration to wait before deleting another batch of config audit reports.
   batchDeleteDelay: 10s
 image:

--- a/deploy/static/02-starboard-operator.rbac.yaml
+++ b/deploy/static/02-starboard-operator.rbac.yaml
@@ -69,6 +69,7 @@ rules:
       - replicasets
       - statefulsets
       - daemonsets
+      - deployments
     verbs:
       - get
       - list

--- a/deploy/static/04-starboard-operator.deployment.yaml
+++ b/deploy/static/04-starboard-operator.deployment.yaml
@@ -81,6 +81,8 @@ spec:
               value: "true"
             - name: OPERATOR_CONFIG_AUDIT_SCANNER_ENABLED
               value: "true"
+            - name: OPERATOR_VULNERABILITY_SCANNER_SCAN_ONLY_CURRENT_REVISIONS
+              value: "false"
           ports:
             - name: metrics
               containerPort: 8080

--- a/docs/operator/configuration.md
+++ b/docs/operator/configuration.md
@@ -1,34 +1,35 @@
 Configuration of the operator's Pod is done via environment variables at startup.
 
-| NAME                                        | DEFAULT                | DESCRIPTION |
-| ------------------------------------------- | ---------------------- | ----------- |
-| `OPERATOR_NAMESPACE`                        | N/A                    | See [Install modes](#install-modes) |
-| `OPERATOR_TARGET_NAMESPACES`                | N/A                    | See [Install modes](#install-modes) |
-| `OPERATOR_SERVICE_ACCOUNT`                  | `starboard-operator`   | The name of the service account assigned to the operator's pod |
-| `OPERATOR_LOG_DEV_MODE`                     | `false`                | The flag to use (or not use) development mode (more human-readable output, extra stack traces and logging information, etc). |
-| `OPERATOR_SCAN_JOB_TIMEOUT`                 | `5m`                   | The length of time to wait before giving up on a scan job |
-| `OPERATOR_CONCURRENT_SCAN_JOBS_LIMIT`       | `10`                   | The maximum number of scan jobs create by the operator |
-| `OPERATOR_SCAN_JOB_RETRY_AFTER`             | `30s`                  | The duration to wait before retrying a failed scan job |
-| `OPERATOR_BATCH_DELETE_LIMIT`               | `10`                   | The maximum number of config audit reports deleted by the operator when the plugin's config has changed. |
-| `OPERATOR_BATCH_DELETE_DELAY`               | `10s`                  | The duration to wait before deleting another batch of config audit reports. |
-| `OPERATOR_METRICS_BIND_ADDRESS`             | `:8080`                | The TCP address to bind to for serving [Prometheus][prometheus] metrics. It can be set to `0` to disable the metrics serving. |
-| `OPERATOR_HEALTH_PROBE_BIND_ADDRESS`        | `:9090`                | The TCP address to bind to for serving health probes, i.e. `/healthz/` and `/readyz/` endpoints. |
-| `OPERATOR_CIS_KUBERNETES_BENCHMARK_ENABLED` | `true`                 | The flag to enable CIS Kubernetes Benchmark scanner |
-| `OPERATOR_VULNERABILITY_SCANNER_ENABLED`    | `true`                 | The flag to enable vulnerability scanner |
-| `OPERATOR_CONFIG_AUDIT_SCANNER_ENABLED`     | `true`                 | The flag to enable configuration audit scanner |
-| `OPERATOR_LEADER_ELECTION_ENABLED`          | `false`                | The flag to enable operator replica leader election |
-| `OPERATOR_LEADER_ELECTION_ID`               | `starboard-lock`       | The name of the resource lock for leader election |
+| NAME                                                         | DEFAULT              | DESCRIPTION                                                                                                                   |
+| ------------------------------------------------------------ | -------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `OPERATOR_NAMESPACE`                                         | N/A                  | See [Install modes](#install-modes)                                                                                           |
+| `OPERATOR_TARGET_NAMESPACES`                                 | N/A                  | See [Install modes](#install-modes)                                                                                           |
+| `OPERATOR_SERVICE_ACCOUNT`                                   | `starboard-operator` | The name of the service account assigned to the operator's pod                                                                |
+| `OPERATOR_LOG_DEV_MODE`                                      | `false`              | The flag to use (or not use) development mode (more human-readable output, extra stack traces and logging information, etc).  |
+| `OPERATOR_SCAN_JOB_TIMEOUT`                                  | `5m`                 | The length of time to wait before giving up on a scan job                                                                     |
+| `OPERATOR_CONCURRENT_SCAN_JOBS_LIMIT`                        | `10`                 | The maximum number of scan jobs create by the operator                                                                        |
+| `OPERATOR_SCAN_JOB_RETRY_AFTER`                              | `30s`                | The duration to wait before retrying a failed scan job                                                                        |
+| `OPERATOR_BATCH_DELETE_LIMIT`                                | `10`                 | The maximum number of config audit reports deleted by the operator when the plugin's config has changed.                      |
+| `OPERATOR_BATCH_DELETE_DELAY`                                | `10s`                | The duration to wait before deleting another batch of config audit reports.                                                   |
+| `OPERATOR_METRICS_BIND_ADDRESS`                              | `:8080`              | The TCP address to bind to for serving [Prometheus][prometheus] metrics. It can be set to `0` to disable the metrics serving. |
+| `OPERATOR_HEALTH_PROBE_BIND_ADDRESS`                         | `:9090`              | The TCP address to bind to for serving health probes, i.e. `/healthz/` and `/readyz/` endpoints.                              |
+| `OPERATOR_CIS_KUBERNETES_BENCHMARK_ENABLED`                  | `true`               | The flag to enable CIS Kubernetes Benchmark scanner                                                                           |
+| `OPERATOR_VULNERABILITY_SCANNER_ENABLED`                     | `true`               | The flag to enable vulnerability scanner                                                                                      |
+| `OPERATOR_CONFIG_AUDIT_SCANNER_ENABLED`                      | `true`               | The flag to enable configuration audit scanner                                                                                |
+| `OPERATOR_VULNERABILITY_SCANNER_SCAN_ONLY_CURRENT_REVISIONS` | `false`              | The flag to enable vulnerability scanner to only scan the current revision of a deployment                                    |
+| `OPERATOR_LEADER_ELECTION_ENABLED`                           | `false`              | The flag to enable operator replica leader election                                                                           |
+| `OPERATOR_LEADER_ELECTION_ID`                                | `starboard-lock`     | The name of the resource lock for leader election                                                                             |
 
 ## Install Modes
 
 The values of the `OPERATOR_NAMESPACE` and `OPERATOR_TARGET_NAMESPACES` determine
 the install mode, which in turn determines the multitenancy support of the operator.
 
-| MODE            | OPERATOR_NAMESPACE | OPERATOR_TARGET_NAMESPACES | DESCRIPTION |
-| --------------- | ------------------ | -------------------------- | ----------- |
-| OwnNamespace    | `operators`        | `operators`                | The operator can be configured to watch events in the namespace it is deployed in. |
+| MODE            | OPERATOR_NAMESPACE | OPERATOR_TARGET_NAMESPACES | DESCRIPTION                                                                                                    |
+| --------------- | ------------------ | -------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| OwnNamespace    | `operators`        | `operators`                | The operator can be configured to watch events in the namespace it is deployed in.                             |
 | SingleNamespace | `operators`        | `foo`                      | The operator can be configured to watch for events in a single namespace that the operator is not deployed in. |
-| MultiNamespace  | `operators`        | `foo,bar,baz`              | The operator can be configured to watch for events in more than one namespace. |
-| AllNamespaces   | `operators`        | (blank string)             | The operator can be configured to watch for events in all namespaces. |
+| MultiNamespace  | `operators`        | `foo,bar,baz`              | The operator can be configured to watch for events in more than one namespace.                                 |
+| AllNamespaces   | `operators`        | (blank string)             | The operator can be configured to watch for events in all namespaces.                                          |
 
 [prometheus]: https://github.com/prometheus

--- a/docs/operator/getting-started.md
+++ b/docs/operator/getting-started.md
@@ -98,6 +98,9 @@ collection. For example, when the previous ReplicaSet named `nginx-6d4cf56db6` i
 `replicaset-nginx-6d4cf56db6-nginx` as well as the ConfigAuditReport named `replicaset-nginx-6d4cf56db6` are
 automatically garbage collected.
 
+If you only want the latest replicaset in your deployment to be scanned for vulnerabilities you can define `OPERATOR_VULNERABILITY_SCANNER_SCAN_ONLY_CURRENT_REVISIONS=true`
+in your operator deployment. This can be useful if you only want to know about vulnerability that is currently a potential issue.
+
 !!! tip
     You can get and describe `vulnerabilityreports` and `configauditreports` as built-in Kubernetes objects:
     ```

--- a/pkg/operator/controller/vulnerabilityreport.go
+++ b/pkg/operator/controller/vulnerabilityreport.go
@@ -108,6 +108,18 @@ func (r *VulnerabilityReportReconciler) reconcileWorkload(workloadKind kube.Kind
 			}
 		}
 
+		if r.Config.VulnerabilityScannerScanOnlyCurrentRevisions && workloadKind == kube.KindReplicaSet {
+			controller := metav1.GetControllerOf(workloadObj)
+			activeReplicaSet, err := r.IsActiveReplicaSet(ctx, workloadObj, controller)
+			if err != nil {
+				return ctrl.Result{}, fmt.Errorf("failed checking current revision: %w", err)
+			}
+			if !activeReplicaSet {
+				log.V(1).Info("Ignoring inactive ReplicaSet", "controllerKind", controller.Kind, "controllerName", controller.Name)
+				return ctrl.Result{}, nil
+			}
+		}
+
 		// Skip processing if it's a Job controlled by CronJob.
 		if workloadKind == kube.KindJob {
 			controller := metav1.GetControllerOf(workloadObj)

--- a/pkg/operator/etc/config.go
+++ b/pkg/operator/etc/config.go
@@ -10,22 +10,23 @@ import (
 
 // Config defines parameters for running the operator.
 type Config struct {
-	Namespace                     string        `env:"OPERATOR_NAMESPACE"`
-	TargetNamespaces              string        `env:"OPERATOR_TARGET_NAMESPACES"`
-	ServiceAccount                string        `env:"OPERATOR_SERVICE_ACCOUNT" envDefault:"starboard-operator"`
-	LogDevMode                    bool          `env:"OPERATOR_LOG_DEV_MODE" envDefault:"false"`
-	ScanJobTimeout                time.Duration `env:"OPERATOR_SCAN_JOB_TIMEOUT" envDefault:"5m"`
-	ConcurrentScanJobsLimit       int           `env:"OPERATOR_CONCURRENT_SCAN_JOBS_LIMIT" envDefault:"10"`
-	ScanJobRetryAfter             time.Duration `env:"OPERATOR_SCAN_JOB_RETRY_AFTER" envDefault:"30s"`
-	BatchDeleteLimit              int           `env:"OPERATOR_BATCH_DELETE_LIMIT" envDefault:"10"`
-	BatchDeleteDelay              time.Duration `env:"OPERATOR_BATCH_DELETE_DELAY" envDefault:"10s"`
-	MetricsBindAddress            string        `env:"OPERATOR_METRICS_BIND_ADDRESS" envDefault:":8080"`
-	HealthProbeBindAddress        string        `env:"OPERATOR_HEALTH_PROBE_BIND_ADDRESS" envDefault:":9090"`
-	CISKubernetesBenchmarkEnabled bool          `env:"OPERATOR_CIS_KUBERNETES_BENCHMARK_ENABLED" envDefault:"true"`
-	VulnerabilityScannerEnabled   bool          `env:"OPERATOR_VULNERABILITY_SCANNER_ENABLED" envDefault:"true"`
-	ConfigAuditScannerEnabled     bool          `env:"OPERATOR_CONFIG_AUDIT_SCANNER_ENABLED" envDefault:"true"`
-	LeaderElectionEnabled         bool          `env:"OPERATOR_LEADER_ELECTION_ENABLED" envDefault:"false"`
-	LeaderElectionID              string        `env:"OPERATOR_LEADER_ELECTION_ID" envDefault:"starboard-lock"`
+	Namespace                                    string        `env:"OPERATOR_NAMESPACE"`
+	TargetNamespaces                             string        `env:"OPERATOR_TARGET_NAMESPACES"`
+	ServiceAccount                               string        `env:"OPERATOR_SERVICE_ACCOUNT" envDefault:"starboard-operator"`
+	LogDevMode                                   bool          `env:"OPERATOR_LOG_DEV_MODE" envDefault:"false"`
+	ScanJobTimeout                               time.Duration `env:"OPERATOR_SCAN_JOB_TIMEOUT" envDefault:"5m"`
+	ConcurrentScanJobsLimit                      int           `env:"OPERATOR_CONCURRENT_SCAN_JOBS_LIMIT" envDefault:"10"`
+	ScanJobRetryAfter                            time.Duration `env:"OPERATOR_SCAN_JOB_RETRY_AFTER" envDefault:"30s"`
+	BatchDeleteLimit                             int           `env:"OPERATOR_BATCH_DELETE_LIMIT" envDefault:"10"`
+	BatchDeleteDelay                             time.Duration `env:"OPERATOR_BATCH_DELETE_DELAY" envDefault:"10s"`
+	MetricsBindAddress                           string        `env:"OPERATOR_METRICS_BIND_ADDRESS" envDefault:":8080"`
+	HealthProbeBindAddress                       string        `env:"OPERATOR_HEALTH_PROBE_BIND_ADDRESS" envDefault:":9090"`
+	CISKubernetesBenchmarkEnabled                bool          `env:"OPERATOR_CIS_KUBERNETES_BENCHMARK_ENABLED" envDefault:"true"`
+	VulnerabilityScannerEnabled                  bool          `env:"OPERATOR_VULNERABILITY_SCANNER_ENABLED" envDefault:"true"`
+	ConfigAuditScannerEnabled                    bool          `env:"OPERATOR_CONFIG_AUDIT_SCANNER_ENABLED" envDefault:"true"`
+	LeaderElectionEnabled                        bool          `env:"OPERATOR_LEADER_ELECTION_ENABLED" envDefault:"false"`
+	LeaderElectionID                             string        `env:"OPERATOR_LEADER_ELECTION_ID" envDefault:"starboard-lock"`
+	VulnerabilityScannerScanOnlyCurrentRevisions bool          `env:"OPERATOR_VULNERABILITY_SCANNER_SCAN_ONLY_CURRENT_REVISIONS" envDefault:"false"`
 }
 
 // GetOperatorConfig loads Config from environment variables.


### PR DESCRIPTION
Add environment variable: OPERATOR_VULNERABILITY_SCANNER_LATEST to be configured in the operator.
Setting this value to true will look through new replicasets and see if `deployment.kubernetes.io/revision` matches with it's deployment owner.
If that is true generate a report, else ignore it.

Solves:
https://github.com/aquasecurity/starboard/discussions/858
https://github.com/aquasecurity/starboard/discussions/668
