### PR TITLE
refactor: rename kube.Object to kube.ObjectRef

### DIFF
--- a/itest/helper/helper.go
+++ b/itest/helper/helper.go
@@ -444,7 +444,7 @@ func (h *Helper) GetActiveReplicaSetForDeployment(namespace, name string) (*apps
 
 func (h *Helper) HasCISKubeBenchReportOwnedBy(node corev1.Node) func() (bool, error) {
 	return func() (bool, error) {
-		report, err := h.kubeBenchReportReader.FindByOwner(context.Background(), kube.Object{Kind: kube.KindNode, Name: node.Name})
+		report, err := h.kubeBenchReportReader.FindByOwner(context.Background(), kube.ObjectRef{Kind: kube.KindNode, Name: node.Name})
 		if err != nil {
 			return false, err
 		}

--- a/itest/matcher/matcher.go
+++ b/itest/matcher/matcher.go
@@ -109,7 +109,7 @@ func (m *vulnerabilityReportMatcher) objectToLabelsAsMatchKeys(obj client.Object
 		kind = gvk.Kind
 	}
 
-	labels := kube.PartialObjectToLabels(kube.Object{
+	labels := kube.ObjectRefToLabels(kube.ObjectRef{
 		Kind:      kube.Kind(kind),
 		Name:      obj.GetName(),
 		Namespace: obj.GetNamespace(),

--- a/itest/starboard/starboard_cli_test.go
+++ b/itest/starboard/starboard_cli_test.go
@@ -222,7 +222,7 @@ var _ = Describe("Starboard CLI", func() {
 				}, GinkgoWriter, GinkgoWriter)
 				Expect(err).ToNot(HaveOccurred())
 
-				reports, err := vulnerabilityreport.NewReadWriter(kubeClient).FindByOwner(ctx, kube.Object{
+				reports, err := vulnerabilityreport.NewReadWriter(kubeClient).FindByOwner(ctx, kube.ObjectRef{
 					Kind:      kube.KindPod,
 					Name:      pod.Name,
 					Namespace: pod.Namespace,
@@ -266,7 +266,7 @@ var _ = Describe("Starboard CLI", func() {
 				}, GinkgoWriter, GinkgoWriter)
 				Expect(err).ToNot(HaveOccurred())
 
-				reports, err := vulnerabilityreport.NewReadWriter(kubeClient).FindByOwner(ctx, kube.Object{
+				reports, err := vulnerabilityreport.NewReadWriter(kubeClient).FindByOwner(ctx, kube.ObjectRef{
 					Kind:      kube.KindPod,
 					Name:      pod.Name,
 					Namespace: pod.Namespace,
@@ -476,7 +476,7 @@ var _ = Describe("Starboard CLI", func() {
 				}, GinkgoWriter, GinkgoWriter)
 				Expect(err).ToNot(HaveOccurred())
 
-				reports, err := vulnerabilityreport.NewReadWriter(kubeClient).FindByOwner(ctx, kube.Object{
+				reports, err := vulnerabilityreport.NewReadWriter(kubeClient).FindByOwner(ctx, kube.ObjectRef{
 					Kind:      kube.KindReplicaSet,
 					Name:      rs.Name,
 					Namespace: rs.Namespace,
@@ -541,7 +541,7 @@ var _ = Describe("Starboard CLI", func() {
 				}, GinkgoWriter, GinkgoWriter)
 				Expect(err).ToNot(HaveOccurred())
 
-				reports, err := vulnerabilityreport.NewReadWriter(kubeClient).FindByOwner(ctx, kube.Object{
+				reports, err := vulnerabilityreport.NewReadWriter(kubeClient).FindByOwner(ctx, kube.ObjectRef{
 					Kind:      kube.KindReplicationController,
 					Name:      rc.Name,
 					Namespace: rc.Namespace,
@@ -595,7 +595,7 @@ var _ = Describe("Starboard CLI", func() {
 				revision, err := objectResolver.ReplicaSetByDeployment(ctx, deploy)
 				Expect(err).ToNot(HaveOccurred())
 
-				reports, err := vulnerabilityreport.NewReadWriter(kubeClient).FindByOwner(ctx, kube.Object{
+				reports, err := vulnerabilityreport.NewReadWriter(kubeClient).FindByOwner(ctx, kube.ObjectRef{
 					Kind:      kube.KindReplicaSet,
 					Name:      revision.Name,
 					Namespace: revision.Namespace,
@@ -649,7 +649,7 @@ var _ = Describe("Starboard CLI", func() {
 				revision, err := objectResolver.ReplicaSetByDeployment(ctx, deploy)
 				Expect(err).ToNot(HaveOccurred())
 
-				reports, err := vulnerabilityreport.NewReadWriter(kubeClient).FindByOwner(ctx, kube.Object{
+				reports, err := vulnerabilityreport.NewReadWriter(kubeClient).FindByOwner(ctx, kube.ObjectRef{
 					Kind:      kube.KindReplicaSet,
 					Name:      revision.Name,
 					Namespace: revision.Namespace,
@@ -716,7 +716,7 @@ var _ = Describe("Starboard CLI", func() {
 				}, GinkgoWriter, GinkgoWriter)
 				Expect(err).ToNot(HaveOccurred())
 
-				reports, err := vulnerabilityreport.NewReadWriter(kubeClient).FindByOwner(ctx, kube.Object{
+				reports, err := vulnerabilityreport.NewReadWriter(kubeClient).FindByOwner(ctx, kube.ObjectRef{
 					Kind:      kube.KindStatefulSet,
 					Name:      sts.Name,
 					Namespace: sts.Namespace,
@@ -782,7 +782,7 @@ var _ = Describe("Starboard CLI", func() {
 				}, GinkgoWriter, GinkgoWriter)
 				Expect(err).ToNot(HaveOccurred())
 
-				reports, err := vulnerabilityreport.NewReadWriter(kubeClient).FindByOwner(ctx, kube.Object{
+				reports, err := vulnerabilityreport.NewReadWriter(kubeClient).FindByOwner(ctx, kube.ObjectRef{
 					Kind:      kube.KindDaemonSet,
 					Name:      ds.Name,
 					Namespace: ds.Namespace,

--- a/pkg/cmd/commands.go
+++ b/pkg/cmd/commands.go
@@ -20,7 +20,7 @@ func SetGlobalFlags(cf *genericclioptions.ConfigFlags, cmd *cobra.Command) {
 	}
 }
 
-func WorkloadFromArgs(mapper meta.RESTMapper, namespace string, args []string) (workload kube.Object, gvk schema.GroupVersionKind, err error) {
+func WorkloadFromArgs(mapper meta.RESTMapper, namespace string, args []string) (workload kube.ObjectRef, gvk schema.GroupVersionKind, err error) {
 	if len(args) < 1 {
 		err = errors.New("required workload kind and name not specified")
 		return
@@ -44,7 +44,7 @@ func WorkloadFromArgs(mapper meta.RESTMapper, namespace string, args []string) (
 		err = errors.New("required workload name is blank")
 		return
 	}
-	workload = kube.Object{
+	workload = kube.ObjectRef{
 		Namespace: namespace,
 		Kind:      kube.Kind(gvk.Kind),
 		Name:      resourceName,

--- a/pkg/configauditreport/builder.go
+++ b/pkg/configauditreport/builder.go
@@ -132,7 +132,7 @@ func (s *ScanJobBuilder) Get() (*batchv1.Job, []*corev1.Secret, error) {
 }
 
 func GetScanJobName(obj client.Object) string {
-	return fmt.Sprintf("scan-configauditreport-%s", kube.ComputeHash(kube.Object{
+	return fmt.Sprintf("scan-configauditreport-%s", kube.ComputeHash(kube.ObjectRef{
 		Kind:      kube.Kind(obj.GetObjectKind().GroupVersionKind().Kind),
 		Namespace: obj.GetNamespace(),
 		Name:      obj.GetName(),

--- a/pkg/configauditreport/builder_test.go
+++ b/pkg/configauditreport/builder_test.go
@@ -175,7 +175,7 @@ func TestScanJobBuilder(t *testing.T) {
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(job).To(Equal(&batchv1.Job{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "scan-configauditreport-fcc9884cb",
+				Name:      "scan-configauditreport-64d65c457",
 				Namespace: "starboard-ns",
 				Labels: map[string]string{
 					starboard.LabelResourceSpecHash:         "58b8989656",
@@ -235,7 +235,7 @@ func TestScanJobBuilder(t *testing.T) {
 		g.Expect(job).NotTo(BeNil())
 		g.Expect(job).To(Equal(&batchv1.Job{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "scan-configauditreport-58ddcc9dcb",
+				Name:      "scan-configauditreport-5bfbdd65c9",
 				Namespace: "starboard-ns",
 				Labels: map[string]string{
 					starboard.LabelResourceSpecHash:         "7c48697ccf",

--- a/pkg/configauditreport/io_test.go
+++ b/pkg/configauditreport/io_test.go
@@ -167,7 +167,7 @@ func TestReadWriter(t *testing.T) {
 			}).Build()
 
 		readWriter := configauditreport.NewReadWriter(client)
-		found, err := readWriter.FindReportByOwner(context.TODO(), kube.Object{
+		found, err := readWriter.FindReportByOwner(context.TODO(), kube.ObjectRef{
 			Kind:      kube.KindDeployment,
 			Name:      "my-deploy",
 			Namespace: "my-namespace",
@@ -223,7 +223,7 @@ func TestReadWriter(t *testing.T) {
 			}).Build()
 
 		readWriter := configauditreport.NewReadWriter(client)
-		found, err := readWriter.FindReportByOwner(context.TODO(), kube.Object{
+		found, err := readWriter.FindReportByOwner(context.TODO(), kube.ObjectRef{
 			Kind:      kube.KindRole,
 			Name:      "system:controller:token-cleaner",
 			Namespace: "kube-system",
@@ -392,7 +392,7 @@ func TestReadWriter(t *testing.T) {
 			Build()
 
 		readWriter := configauditreport.NewReadWriter(client)
-		found, err := readWriter.FindClusterReportByOwner(context.TODO(), kube.Object{
+		found, err := readWriter.FindClusterReportByOwner(context.TODO(), kube.ObjectRef{
 			Kind: "ClusterRole",
 			Name: "editor",
 		})

--- a/pkg/configauditreport/scanner.go
+++ b/pkg/configauditreport/scanner.go
@@ -45,11 +45,11 @@ func NewScanner(
 	}
 }
 
-func (s *Scanner) Scan(ctx context.Context, partial kube.Object) (*ReportBuilder, error) {
+func (s *Scanner) Scan(ctx context.Context, partial kube.ObjectRef) (*ReportBuilder, error) {
 	if !s.supportsKind(partial.Kind) {
 		return nil, fmt.Errorf("kind %s is not supported by %s plugin", partial.Kind, s.pluginContext.GetName())
 	}
-	obj, err := s.objectResolver.GetObjectFromPartialObject(ctx, partial)
+	obj, err := s.objectResolver.ObjectFromObjectRef(ctx, partial)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kube/object_test.go
+++ b/pkg/kube/object_test.go
@@ -94,15 +94,15 @@ func TestIsClusterScopedKind(t *testing.T) {
 	}
 }
 
-func TestPartialObjectToLabels(t *testing.T) {
+func TestObjectRefToLabels(t *testing.T) {
 	testCases := []struct {
 		name   string
-		object kube.Object
+		object kube.ObjectRef
 		labels map[string]string
 	}{
 		{
 			name: "Should map object with simple name",
-			object: kube.Object{
+			object: kube.ObjectRef{
 				Kind:      kube.KindPod,
 				Name:      "my-pod",
 				Namespace: "production",
@@ -115,7 +115,7 @@ func TestPartialObjectToLabels(t *testing.T) {
 		},
 		{
 			name: "Should map object with name that is not a valid label",
-			object: kube.Object{
+			object: kube.ObjectRef{
 				Kind: kube.KindClusterRole,
 				Name: "system:controller:namespace-controller",
 			},
@@ -128,7 +128,7 @@ func TestPartialObjectToLabels(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.labels, kube.PartialObjectToLabels(tc.object))
+			assert.Equal(t, tc.labels, kube.ObjectRefToLabels(tc.object))
 		})
 	}
 }
@@ -242,12 +242,12 @@ func TestContainerImages_AsJSON_And_FromJSON(t *testing.T) {
 	assert.Equal(t, containerImages, newContainerImages)
 }
 
-func TestGetPartialObjectFromKindAndNamespacedName(t *testing.T) {
-	partial := kube.GetPartialObjectFromKindAndNamespacedName(kube.KindReplicaSet, types.NamespacedName{
+func TestObjectRefFromKindAndNamespacedName(t *testing.T) {
+	partial := kube.ObjectRefFromKindAndNamespacedName(kube.KindReplicaSet, types.NamespacedName{
 		Namespace: "prod",
 		Name:      "wordpress",
 	})
-	assert.Equal(t, kube.Object{
+	assert.Equal(t, kube.ObjectRef{
 		Kind:      kube.KindReplicaSet,
 		Name:      "wordpress",
 		Namespace: "prod",
@@ -568,7 +568,7 @@ func TestObjectResolver_GetRelatedReplicasetName(t *testing.T) {
 	).Build()}
 
 	t.Run("Should return error for unsupported kind", func(t *testing.T) {
-		_, err := instance.GetRelatedReplicasetName(context.Background(), kube.Object{
+		_, err := instance.GetRelatedReplicasetName(context.Background(), kube.ObjectRef{
 			Kind:      kube.KindStatefulSet,
 			Name:      "statefulapp",
 			Namespace: corev1.NamespaceDefault,
@@ -577,7 +577,7 @@ func TestObjectResolver_GetRelatedReplicasetName(t *testing.T) {
 	})
 
 	t.Run("Should return ReplicaSet name for the specified Deployment", func(t *testing.T) {
-		name, err := instance.GetRelatedReplicasetName(context.Background(), kube.Object{
+		name, err := instance.GetRelatedReplicasetName(context.Background(), kube.ObjectRef{
 			Kind:      kube.KindDeployment,
 			Name:      "nginx",
 			Namespace: corev1.NamespaceDefault,
@@ -587,7 +587,7 @@ func TestObjectResolver_GetRelatedReplicasetName(t *testing.T) {
 	})
 
 	t.Run("Should return ReplicaSet name for the specified Deployment", func(t *testing.T) {
-		name, err := instance.GetRelatedReplicasetName(context.Background(), kube.Object{
+		name, err := instance.GetRelatedReplicasetName(context.Background(), kube.ObjectRef{
 			Kind:      kube.KindPod,
 			Name:      "nginx-549f5fcb58-7cr5b",
 			Namespace: corev1.NamespaceDefault,
@@ -598,11 +598,11 @@ func TestObjectResolver_GetRelatedReplicasetName(t *testing.T) {
 
 }
 
-func TestPartialObjectFromObjectMetadata(t *testing.T) {
+func TestObjectRefFromObjectMeta(t *testing.T) {
 	testCases := []struct {
 		name          string
 		object        metav1.ObjectMeta
-		expected      kube.Object
+		expected      kube.ObjectRef
 		expectedError string
 	}{
 		{
@@ -617,7 +617,7 @@ func TestPartialObjectFromObjectMetadata(t *testing.T) {
 					starboard.LabelResourceName: "system:admin",
 				},
 			},
-			expected: kube.Object{Kind: kube.KindRole, Name: "system:admin", Namespace: "kube-system"},
+			expected: kube.ObjectRef{Kind: kube.KindRole, Name: "system:admin", Namespace: "kube-system"},
 		},
 		{
 			name: "Test RoleBinding",
@@ -631,7 +631,7 @@ func TestPartialObjectFromObjectMetadata(t *testing.T) {
 					starboard.LabelResourceName: "system:admin:binding",
 				},
 			},
-			expected: kube.Object{Kind: kube.KindRoleBinding, Name: "system:admin:binding", Namespace: "kube-system"},
+			expected: kube.ObjectRef{Kind: kube.KindRoleBinding, Name: "system:admin:binding", Namespace: "kube-system"},
 		},
 		{
 			name: "Kind ClusterRole",
@@ -645,7 +645,7 @@ func TestPartialObjectFromObjectMetadata(t *testing.T) {
 					starboard.LabelResourceName: "system:netnode",
 				},
 			},
-			expected: kube.Object{Kind: kube.KindClusterRole, Name: "system:netnode"},
+			expected: kube.ObjectRef{Kind: kube.KindClusterRole, Name: "system:netnode"},
 		},
 		{
 			name: "Kind ClusterRoleBinding",
@@ -659,7 +659,7 @@ func TestPartialObjectFromObjectMetadata(t *testing.T) {
 					starboard.LabelResourceName: "system:netnode:binding",
 				},
 			},
-			expected: kube.Object{Kind: kube.KindClusterRoleBindings, Name: "system:netnode:binding"},
+			expected: kube.ObjectRef{Kind: kube.KindClusterRoleBindings, Name: "system:netnode:binding"},
 		},
 		{
 			name: "Kind Pod",
@@ -670,7 +670,7 @@ func TestPartialObjectFromObjectMetadata(t *testing.T) {
 					starboard.LabelResourceName:      "nginx-pod",
 				},
 			},
-			expected: kube.Object{Kind: kube.KindPod, Name: "nginx-pod", Namespace: "default"},
+			expected: kube.ObjectRef{Kind: kube.KindPod, Name: "nginx-pod", Namespace: "default"},
 		},
 		{
 			name: "Kind Deployment",
@@ -681,7 +681,7 @@ func TestPartialObjectFromObjectMetadata(t *testing.T) {
 					starboard.LabelResourceName:      "nginx-deployment",
 				},
 			},
-			expected: kube.Object{Kind: kube.KindDeployment, Name: "nginx-deployment", Namespace: "default"},
+			expected: kube.ObjectRef{Kind: kube.KindDeployment, Name: "nginx-deployment", Namespace: "default"},
 		},
 		{
 			name: "Kind DaemonSet",
@@ -692,7 +692,7 @@ func TestPartialObjectFromObjectMetadata(t *testing.T) {
 					starboard.LabelResourceName:      "nginx-ds",
 				},
 			},
-			expected: kube.Object{Kind: kube.KindDaemonSet, Name: "nginx-ds", Namespace: "default"},
+			expected: kube.ObjectRef{Kind: kube.KindDaemonSet, Name: "nginx-ds", Namespace: "default"},
 		},
 		{
 			name: fmt.Sprintf("Should return error when %s label is missing", starboard.LabelResourceKind),
@@ -708,7 +708,7 @@ func TestPartialObjectFromObjectMetadata(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			actual, err := kube.PartialObjectFromObjectMetadata(tc.object)
+			actual, err := kube.ObjectRefFromObjectMeta(tc.object)
 			if tc.expectedError == "" {
 				require.NoError(t, err)
 				assert.Equal(t, tc.expected, actual)

--- a/pkg/kubebench/io.go
+++ b/pkg/kubebench/io.go
@@ -15,7 +15,7 @@ type Writer interface {
 }
 
 type Reader interface {
-	FindByOwner(ctx context.Context, node kube.Object) (*v1alpha1.CISKubeBenchReport, error)
+	FindByOwner(ctx context.Context, node kube.ObjectRef) (*v1alpha1.CISKubeBenchReport, error)
 }
 
 type ReadWriter interface {
@@ -55,7 +55,7 @@ func (w *rw) Write(ctx context.Context, report v1alpha1.CISKubeBenchReport) erro
 	return err
 }
 
-func (w *rw) FindByOwner(ctx context.Context, node kube.Object) (*v1alpha1.CISKubeBenchReport, error) {
+func (w *rw) FindByOwner(ctx context.Context, node kube.ObjectRef) (*v1alpha1.CISKubeBenchReport, error) {
 	report := &v1alpha1.CISKubeBenchReport{}
 	err := w.client.Get(ctx, types.NamespacedName{
 		Name: node.Name,

--- a/pkg/kubebench/io_test.go
+++ b/pkg/kubebench/io_test.go
@@ -214,7 +214,7 @@ func TestReadWriter(t *testing.T) {
 			Build()
 		instance := kubebench.NewReadWriter(client)
 
-		found, err := instance.FindByOwner(context.Background(), kube.Object{Name: "worker"})
+		found, err := instance.FindByOwner(context.Background(), kube.ObjectRef{Name: "worker"})
 		require.NoError(t, err)
 
 		assert.Equal(t, &v1alpha1.CISKubeBenchReport{

--- a/pkg/operator/controller/ciskubebenchreport.go
+++ b/pkg/operator/controller/ciskubebenchreport.go
@@ -130,7 +130,7 @@ func (r *CISKubeBenchReportReconciler) reconcileNodes() reconcile.Func {
 }
 
 func (r *CISKubeBenchReportReconciler) hasReport(ctx context.Context, node *corev1.Node) (bool, error) {
-	report, err := r.ReadWriter.FindByOwner(ctx, kube.Object{Kind: kube.KindNode, Name: node.Name})
+	report, err := r.ReadWriter.FindByOwner(ctx, kube.ObjectRef{Kind: kube.KindNode, Name: node.Name})
 	if err != nil {
 		return false, err
 	}
@@ -240,7 +240,7 @@ func (r *CISKubeBenchReportReconciler) reconcileJobs() reconcile.Func {
 func (r *CISKubeBenchReportReconciler) processCompleteScanJob(ctx context.Context, job *batchv1.Job) error {
 	log := r.Logger.WithValues("job", fmt.Sprintf("%s/%s", job.Namespace, job.Name))
 
-	nodeRef, err := kube.PartialObjectFromObjectMetadata(job.ObjectMeta)
+	nodeRef, err := kube.ObjectRefFromObjectMeta(job.ObjectMeta)
 	if err != nil {
 		return fmt.Errorf("getting owner ref from scan job metadata: %w", err)
 	}

--- a/pkg/operator/controller/vulnerabilityreport.go
+++ b/pkg/operator/controller/vulnerabilityreport.go
@@ -87,10 +87,10 @@ func (r *VulnerabilityReportReconciler) reconcileWorkload(workloadKind kube.Kind
 	return func(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 		log := r.Logger.WithValues("kind", workloadKind, "name", req.NamespacedName)
 
-		workloadPartial := kube.GetPartialObjectFromKindAndNamespacedName(workloadKind, req.NamespacedName)
+		workloadPartial := kube.ObjectRefFromKindAndNamespacedName(workloadKind, req.NamespacedName)
 
 		log.V(1).Info("Getting workload from cache")
-		workloadObj, err := r.GetObjectFromPartialObject(ctx, workloadPartial)
+		workloadObj, err := r.ObjectFromObjectRef(ctx, workloadPartial)
 		if err != nil {
 			if errors.IsNotFound(err) {
 				log.V(1).Info("Ignoring cached workload that must have been deleted")
@@ -176,7 +176,7 @@ func (r *VulnerabilityReportReconciler) reconcileWorkload(workloadKind kube.Kind
 	}
 }
 
-func (r *VulnerabilityReportReconciler) hasReports(ctx context.Context, owner kube.Object, hash string, images kube.ContainerImages) (bool, error) {
+func (r *VulnerabilityReportReconciler) hasReports(ctx context.Context, owner kube.ObjectRef, hash string, images kube.ContainerImages) (bool, error) {
 	// TODO FindByOwner should accept optional label selector to further narrow down search results
 	list, err := r.FindByOwner(ctx, owner)
 	if err != nil {
@@ -200,7 +200,7 @@ func (r *VulnerabilityReportReconciler) hasReports(ctx context.Context, owner ku
 	return reflect.DeepEqual(actual, expected), nil
 }
 
-func (r *VulnerabilityReportReconciler) hasActiveScanJob(ctx context.Context, owner kube.Object, hash string) (bool, *batchv1.Job, error) {
+func (r *VulnerabilityReportReconciler) hasActiveScanJob(ctx context.Context, owner kube.ObjectRef, hash string) (bool, *batchv1.Job, error) {
 	jobName := fmt.Sprintf("scan-vulnerabilityreport-%s", kube.ComputeHash(owner))
 	job := &batchv1.Job{}
 	err := r.Get(ctx, client.ObjectKey{Namespace: r.Config.Namespace, Name: jobName}, job)
@@ -312,18 +312,18 @@ func (r *VulnerabilityReportReconciler) reconcileJobs() reconcile.Func {
 func (r *VulnerabilityReportReconciler) processCompleteScanJob(ctx context.Context, job *batchv1.Job) error {
 	log := r.Logger.WithValues("job", fmt.Sprintf("%s/%s", job.Namespace, job.Name))
 
-	ownerRef, err := kube.PartialObjectFromObjectMetadata(job.ObjectMeta)
+	ownerRef, err := kube.ObjectRefFromObjectMeta(job.ObjectMeta)
 	if err != nil {
 		return fmt.Errorf("getting owner ref from scan job metadata: %w", err)
 	}
 
-	owner, err := r.GetObjectFromPartialObject(ctx, ownerRef)
+	owner, err := r.ObjectFromObjectRef(ctx, ownerRef)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			log.V(1).Info("Report owner must have been deleted", "owner", owner)
 			return r.deleteJob(ctx, job)
 		}
-		return fmt.Errorf("getting object from partial object: %w", err)
+		return fmt.Errorf("getting object from object ref: %w", err)
 	}
 
 	containerImages, err := kube.GetContainerImagesFromJob(job)

--- a/pkg/plugin/conftest/plugin_test.go
+++ b/pkg/plugin/conftest/plugin_test.go
@@ -402,7 +402,7 @@ func TestPlugin_GetScanJobSpec(t *testing.T) {
 		"Affinity":                     Equal(starboard.LinuxNodeAffinity()),
 		"Volumes": ConsistOf(
 			MatchFields(IgnoreExtras, Fields{
-				"Name": Equal("scan-configauditreport-5d4445db4f-volume"),
+				"Name": Equal("scan-configauditreport-789cbb5cc4-volume"),
 				// We cannot inline assert here on other properties with the MatchFields matcher
 				// because the value of the Secret field is the pointer to v1.SecretVolumeSource.
 				// The MatchFields matcher only works with structs :-(
@@ -426,31 +426,31 @@ func TestPlugin_GetScanJobSpec(t *testing.T) {
 				}),
 				"VolumeMounts": ConsistOf(
 					corev1.VolumeMount{
-						Name:      "scan-configauditreport-5d4445db4f-volume",
+						Name:      "scan-configauditreport-789cbb5cc4-volume",
 						MountPath: "/project/policy/kubernetes.rego",
 						SubPath:   "kubernetes.rego",
 						ReadOnly:  true,
 					},
 					corev1.VolumeMount{
-						Name:      "scan-configauditreport-5d4445db4f-volume",
+						Name:      "scan-configauditreport-789cbb5cc4-volume",
 						MountPath: "/project/policy/utils.rego",
 						SubPath:   "utils.rego",
 						ReadOnly:  true,
 					},
 					corev1.VolumeMount{
-						Name:      "scan-configauditreport-5d4445db4f-volume",
+						Name:      "scan-configauditreport-789cbb5cc4-volume",
 						MountPath: "/project/policy/access_to_host_pid.rego",
 						SubPath:   "access_to_host_pid.rego",
 						ReadOnly:  true,
 					},
 					corev1.VolumeMount{
-						Name:      "scan-configauditreport-5d4445db4f-volume",
+						Name:      "scan-configauditreport-789cbb5cc4-volume",
 						MountPath: "/project/policy/cpu_not_limited.rego",
 						SubPath:   "cpu_not_limited.rego",
 						ReadOnly:  true,
 					},
 					corev1.VolumeMount{
-						Name:      "scan-configauditreport-5d4445db4f-volume",
+						Name:      "scan-configauditreport-789cbb5cc4-volume",
 						MountPath: "/project/workload.yaml",
 						SubPath:   "workload.yaml",
 						ReadOnly:  true,
@@ -476,7 +476,7 @@ func TestPlugin_GetScanJobSpec(t *testing.T) {
 		"SecurityContext": Equal(&corev1.PodSecurityContext{}),
 	}))
 	g.Expect(*jobSpec.Volumes[0].VolumeSource.Secret).To(MatchFields(IgnoreExtras, Fields{
-		"SecretName": Equal("scan-configauditreport-5d4445db4f-volume"),
+		"SecretName": Equal("scan-configauditreport-789cbb5cc4-volume"),
 		"Items": ConsistOf(
 			corev1.KeyToPath{
 				Key:  "conftest.library.kubernetes.rego",
@@ -503,7 +503,7 @@ func TestPlugin_GetScanJobSpec(t *testing.T) {
 	g.Expect(secrets).To(ConsistOf(
 		&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "scan-configauditreport-5d4445db4f-volume",
+				Name:      "scan-configauditreport-789cbb5cc4-volume",
 				Namespace: "starboard-ns",
 			},
 			StringData: map[string]string{

--- a/pkg/report/html.go
+++ b/pkg/report/html.go
@@ -32,7 +32,7 @@ func NewWorkloadReporter(clock ext.Clock, client client.Client) WorkloadReporter
 	}
 }
 
-func (h *workloadReporter) RetrieveData(workload kube.Object) (templates.WorkloadReport, error) {
+func (h *workloadReporter) RetrieveData(workload kube.ObjectRef) (templates.WorkloadReport, error) {
 	ctx := context.Background()
 	configAuditReport, err := h.configAuditReportsReader.FindReportByOwnerInHierarchy(ctx, workload)
 	if err != nil {
@@ -66,7 +66,7 @@ func (h *workloadReporter) RetrieveData(workload kube.Object) (templates.Workloa
 	}, nil
 }
 
-func (h *workloadReporter) Generate(workload kube.Object, writer io.Writer) error {
+func (h *workloadReporter) Generate(workload kube.ObjectRef, writer io.Writer) error {
 	data, err := h.RetrieveData(workload)
 	if err != nil {
 		return err
@@ -88,7 +88,7 @@ func NewNamespaceReporter(clock ext.Clock, client client.Client) NamespaceReport
 	}
 }
 
-func (r *namespaceReporter) RetrieveData(namespace kube.Object) (templates.NamespaceReport, error) {
+func (r *namespaceReporter) RetrieveData(namespace kube.ObjectRef) (templates.NamespaceReport, error) {
 	var vulnerabilityReportList v1alpha1.VulnerabilityReportList
 	err := r.client.List(context.Background(), &vulnerabilityReportList, client.InNamespace(namespace.Name))
 	if err != nil {
@@ -229,7 +229,7 @@ func (r *namespaceReporter) topNVulnerabilitiesByScore(reports []v1alpha1.Vulner
 	return vulnerabilities[:ext.MinInt(N, len(vulnerabilities))]
 }
 
-func (r *namespaceReporter) Generate(namespace kube.Object, out io.Writer) error {
+func (r *namespaceReporter) Generate(namespace kube.ObjectRef, out io.Writer) error {
 	data, err := r.RetrieveData(namespace)
 	if err != nil {
 		return err
@@ -253,7 +253,7 @@ func NewNodeReporter(clock ext.Clock, client client.Client) NodeReporter {
 	}
 }
 
-func (r *nodeReporter) Generate(node kube.Object, out io.Writer) error {
+func (r *nodeReporter) Generate(node kube.ObjectRef, out io.Writer) error {
 	data, err := r.RetrieveData(node)
 	if err != nil {
 		return err
@@ -262,7 +262,7 @@ func (r *nodeReporter) Generate(node kube.Object, out io.Writer) error {
 	return nil
 }
 
-func (r *nodeReporter) RetrieveData(node kube.Object) (templates.NodeReport, error) {
+func (r *nodeReporter) RetrieveData(node kube.ObjectRef) (templates.NodeReport, error) {
 	found := &v1alpha1.CISKubeBenchReport{}
 	err := r.client.Get(context.Background(), types.NamespacedName{Name: node.Name}, found)
 	if err != nil {

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -8,16 +8,16 @@ import (
 )
 
 type WorkloadReporter interface {
-	RetrieveData(workload kube.Object) (templates.WorkloadReport, error)
-	Generate(workload kube.Object, out io.Writer) error
+	RetrieveData(workload kube.ObjectRef) (templates.WorkloadReport, error)
+	Generate(workload kube.ObjectRef, out io.Writer) error
 }
 
 type NamespaceReporter interface {
-	RetrieveData(namespace kube.Object) (templates.NamespaceReport, error)
-	Generate(namespace kube.Object, out io.Writer) error
+	RetrieveData(namespace kube.ObjectRef) (templates.NamespaceReport, error)
+	Generate(namespace kube.ObjectRef, out io.Writer) error
 }
 
 type NodeReporter interface {
-	RetrieveData(node kube.Object) (templates.NodeReport, error)
-	Generate(node kube.Object, out io.Writer) error
+	RetrieveData(node kube.ObjectRef) (templates.NodeReport, error)
+	Generate(node kube.ObjectRef, out io.Writer) error
 }

--- a/pkg/report/templates/types.go
+++ b/pkg/report/templates/types.go
@@ -10,7 +10,7 @@ import (
 // WorkloadReport is a structure that holds data to render
 // an HTML report for a specified K8s workload.
 type WorkloadReport struct {
-	Workload    kube.Object
+	Workload    kube.ObjectRef
 	GeneratedAt time.Time
 
 	// FIXME Do not use map as the order of iteration is unpredictable.
@@ -21,7 +21,7 @@ type WorkloadReport struct {
 // NamespaceReport is a structure that holds data to render
 // an HTML report for a specified K8s namespace.
 type NamespaceReport struct {
-	Namespace   kube.Object
+	Namespace   kube.ObjectRef
 	GeneratedAt time.Time
 
 	Top5VulnerableImages []v1alpha1.VulnerabilityReport
@@ -42,7 +42,7 @@ type CheckWithCount struct {
 // NodeReport is a structure that holds data to render
 // an HTML report for a specified K8s node.
 type NodeReport struct {
-	Node        kube.Object
+	Node        kube.ObjectRef
 	GeneratedAt time.Time
 
 	CisKubeBenchReport *v1alpha1.CISKubeBenchReport

--- a/pkg/vulnerabilityreport/builder.go
+++ b/pkg/vulnerabilityreport/builder.go
@@ -130,7 +130,7 @@ func (s *ScanJobBuilder) Get() (*batchv1.Job, []*corev1.Secret, error) {
 }
 
 func GetScanJobName(obj client.Object) string {
-	return fmt.Sprintf("scan-vulnerabilityreport-%s", kube.ComputeHash(kube.Object{
+	return fmt.Sprintf("scan-vulnerabilityreport-%s", kube.ComputeHash(kube.ObjectRef{
 		Kind:      kube.Kind(obj.GetObjectKind().GroupVersionKind().Kind),
 		Namespace: obj.GetNamespace(),
 		Name:      obj.GetName(),

--- a/pkg/vulnerabilityreport/builder_test.go
+++ b/pkg/vulnerabilityreport/builder_test.go
@@ -99,7 +99,7 @@ func TestScanJobBuilder(t *testing.T) {
 	g.Expect(job).ToNot(gomega.BeNil())
 	g.Expect(job).To(gomega.Equal(&batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "scan-vulnerabilityreport-fcc9884cb",
+			Name:      "scan-vulnerabilityreport-64d65c457",
 			Namespace: "starboard-ns",
 			Labels: map[string]string{
 				starboard.LabelK8SAppManagedBy:            "starboard",

--- a/pkg/vulnerabilityreport/io.go
+++ b/pkg/vulnerabilityreport/io.go
@@ -22,15 +22,15 @@ type Writer interface {
 // Reader is the interface that wraps methods for finding v1alpha1.VulnerabilityReport objects.
 //
 // FindByOwner returns the slice of v1alpha1.VulnerabilityReport instances
-// owned by the given kube.Object or an empty slice if the reports are not found.
+// owned by the given kube.ObjectRef or an empty slice if the reports are not found.
 //
 // FindByOwnerInHierarchy is similar to FindByOwner except it tries to lookup
 // v1alpha1.VulnerabilityReport objects owned by related Kubernetes objects.
 // For example, if the given owner is a Deployment, but reports are owned by the
 // active ReplicaSet (current revision) this method will return the reports.
 type Reader interface {
-	FindByOwner(context.Context, kube.Object) ([]v1alpha1.VulnerabilityReport, error)
-	FindByOwnerInHierarchy(ctx context.Context, object kube.Object) ([]v1alpha1.VulnerabilityReport, error)
+	FindByOwner(context.Context, kube.ObjectRef) ([]v1alpha1.VulnerabilityReport, error)
+	FindByOwnerInHierarchy(ctx context.Context, object kube.ObjectRef) ([]v1alpha1.VulnerabilityReport, error)
 }
 
 type ReadWriter interface {
@@ -83,10 +83,10 @@ func (r *readWriter) createOrUpdate(ctx context.Context, report v1alpha1.Vulnera
 	return err
 }
 
-func (r *readWriter) FindByOwner(ctx context.Context, owner kube.Object) ([]v1alpha1.VulnerabilityReport, error) {
+func (r *readWriter) FindByOwner(ctx context.Context, owner kube.ObjectRef) ([]v1alpha1.VulnerabilityReport, error) {
 	var list v1alpha1.VulnerabilityReportList
 
-	labels := client.MatchingLabels(kube.PartialObjectToLabels(owner))
+	labels := client.MatchingLabels(kube.ObjectRefToLabels(owner))
 
 	err := r.List(ctx, &list, labels, client.InNamespace(owner.Namespace))
 	if err != nil {
@@ -96,7 +96,7 @@ func (r *readWriter) FindByOwner(ctx context.Context, owner kube.Object) ([]v1al
 	return list.DeepCopy().Items, nil
 }
 
-func (r *readWriter) FindByOwnerInHierarchy(ctx context.Context, owner kube.Object) ([]v1alpha1.VulnerabilityReport, error) {
+func (r *readWriter) FindByOwnerInHierarchy(ctx context.Context, owner kube.ObjectRef) ([]v1alpha1.VulnerabilityReport, error) {
 	reports, err := r.FindByOwner(ctx, owner)
 	if err != nil {
 		return nil, err
@@ -108,7 +108,7 @@ func (r *readWriter) FindByOwnerInHierarchy(ctx context.Context, owner kube.Obje
 		if err != nil {
 			return nil, fmt.Errorf("getting replicaset related to %s/%s: %w", owner.Kind, owner.Name, err)
 		}
-		reports, err = r.FindByOwner(ctx, kube.Object{
+		reports, err = r.FindByOwner(ctx, kube.ObjectRef{
 			Kind:      kube.KindReplicaSet,
 			Name:      rsName,
 			Namespace: owner.Namespace,

--- a/pkg/vulnerabilityreport/io_test.go
+++ b/pkg/vulnerabilityreport/io_test.go
@@ -241,7 +241,7 @@ func TestNewReadWriter(t *testing.T) {
 		}).Build()
 
 		readWriter := vulnerabilityreport.NewReadWriter(client)
-		list, err := readWriter.FindByOwner(context.TODO(), kube.Object{
+		list, err := readWriter.FindByOwner(context.TODO(), kube.ObjectRef{
 			Kind:      kube.KindDeployment,
 			Name:      "my-deploy",
 			Namespace: "my-namespace",

--- a/pkg/vulnerabilityreport/scanner.go
+++ b/pkg/vulnerabilityreport/scanner.go
@@ -61,10 +61,10 @@ func NewScanner(
 // or fails. When succeeded it parses container logs and coverts the output
 // to instances of v1alpha1.VulnerabilityReport by delegating such transformation
 // logic also to the Plugin.
-func (s *Scanner) Scan(ctx context.Context, workload kube.Object) ([]v1alpha1.VulnerabilityReport, error) {
+func (s *Scanner) Scan(ctx context.Context, workload kube.ObjectRef) ([]v1alpha1.VulnerabilityReport, error) {
 	klog.V(3).Infof("Getting Pod template for workload: %v", workload)
 
-	workloadObj, err := s.objectResolver.GetObjectFromPartialObject(ctx, workload)
+	workloadObj, err := s.objectResolver.ObjectFromObjectRef(ctx, workload)
 	if err != nil {
 		return nil, fmt.Errorf("resolving object: %w", err)
 	}


### PR DESCRIPTION
There is no good moment for such refactoring but I found
kube.Object pretty confusing with ubiquitous client.Object
defined by the controller-runtime module. We use both
types throughout the code in the same source files
so this patch renames kube.Object to kube.ObjectRef.

Signed-off-by: Daniel Pacak <pacak.daniel@gmail.com>