### PR TITLE
PET-1192 - Add image subcommand to trivy plugin

### DIFF
--- a/pkg/plugin/trivy/plugin.go
+++ b/pkg/plugin/trivy/plugin.go
@@ -250,13 +250,13 @@ const (
 // volume shared with main containers. In other words, the init container runs
 // the following Trivy command:
 //
-//     trivy --download-db-only --cache-dir /var/lib/trivy
+//     trivy --cache-dir /var/lib/trivy image --download-db-only
 //
 // The number of main containers correspond to the number of containers
 // defined for the scanned workload. Each container runs the Trivy image scan
 // command and skips the database download:
 //
-//     trivy --skip-update --cache-dir /var/lib/trivy \
+//     trivy --cache-dir /var/lib/trivy image --skip-update \
 //       --format json <container image>
 func (p *plugin) getPodSpecForStandaloneMode(ctx starboard.PluginContext, config Config, spec corev1.PodSpec, credentials map[string]docker.Auth) (corev1.PodSpec, []*corev1.Secret, error) {
 	var secret *corev1.Secret
@@ -338,9 +338,10 @@ func (p *plugin) getPodSpecForStandaloneMode(ctx starboard.PluginContext, config
 			"trivy",
 		},
 		Args: []string{
-			"--download-db-only",
 			"--cache-dir",
 			"/var/lib/trivy",
+			"image",
+			"--download-db-only",
 		},
 		Resources: requirements,
 		VolumeMounts: []corev1.VolumeMount{
@@ -550,10 +551,11 @@ func (p *plugin) getPodSpecForStandaloneMode(ctx starboard.PluginContext, config
 				"trivy",
 			},
 			Args: []string{
-				"--skip-update",
 				"--cache-dir",
 				"/var/lib/trivy",
 				"--quiet",
+				"image",
+				"--skip-update",
 				"--format",
 				"json",
 				optionalMirroredImage,

--- a/pkg/plugin/trivy/plugin_test.go
+++ b/pkg/plugin/trivy/plugin_test.go
@@ -542,8 +542,9 @@ func TestPlugin_GetScanJobSpec(t *testing.T) {
 							"trivy",
 						},
 						Args: []string{
-							"--download-db-only",
 							"--cache-dir", "/var/lib/trivy",
+							"image",
+							"--download-db-only",
 						},
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
@@ -660,9 +661,10 @@ func TestPlugin_GetScanJobSpec(t *testing.T) {
 							"trivy",
 						},
 						Args: []string{
-							"--skip-update",
 							"--cache-dir", "/var/lib/trivy",
 							"--quiet",
+							"image",
+							"--skip-update",
 							"--format", "json",
 							"nginx:1.16",
 						},
@@ -791,8 +793,9 @@ func TestPlugin_GetScanJobSpec(t *testing.T) {
 							"trivy",
 						},
 						Args: []string{
-							"--download-db-only",
 							"--cache-dir", "/var/lib/trivy",
+							"image",
+							"--download-db-only",
 						},
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
@@ -913,9 +916,10 @@ func TestPlugin_GetScanJobSpec(t *testing.T) {
 							"trivy",
 						},
 						Args: []string{
-							"--skip-update",
 							"--cache-dir", "/var/lib/trivy",
 							"--quiet",
+							"image",
+							"--skip-update",
 							"--format", "json",
 							"poc.myregistry.harbor.com.pl/nginx:1.16",
 						},
@@ -1043,8 +1047,9 @@ func TestPlugin_GetScanJobSpec(t *testing.T) {
 							"trivy",
 						},
 						Args: []string{
-							"--download-db-only",
 							"--cache-dir", "/var/lib/trivy",
+							"image",
+							"--download-db-only",
 						},
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
@@ -1165,9 +1170,10 @@ func TestPlugin_GetScanJobSpec(t *testing.T) {
 							"trivy",
 						},
 						Args: []string{
-							"--skip-update",
 							"--cache-dir", "/var/lib/trivy",
 							"--quiet",
+							"image",
+							"--skip-update",
 							"--format", "json",
 							"poc.myregistry.harbor.com.pl/nginx:1.16",
 						},
@@ -1316,8 +1322,9 @@ CVE-2019-1543`,
 							"trivy",
 						},
 						Args: []string{
-							"--download-db-only",
 							"--cache-dir", "/var/lib/trivy",
+							"image",
+							"--download-db-only",
 						},
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
@@ -1438,9 +1445,10 @@ CVE-2019-1543`,
 							"trivy",
 						},
 						Args: []string{
-							"--skip-update",
 							"--cache-dir", "/var/lib/trivy",
 							"--quiet",
+							"image",
+							"--skip-update",
 							"--format", "json",
 							"nginx:1.16",
 						},
@@ -1576,8 +1584,9 @@ CVE-2019-1543`,
 							"trivy",
 						},
 						Args: []string{
-							"--download-db-only",
 							"--cache-dir", "/var/lib/trivy",
+							"image",
+							"--download-db-only",
 						},
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
@@ -1694,9 +1703,10 @@ CVE-2019-1543`,
 							"trivy",
 						},
 						Args: []string{
-							"--skip-update",
 							"--cache-dir", "/var/lib/trivy",
 							"--quiet",
+							"image",
+							"--skip-update",
 							"--format", "json",
 							"mirror.io/library/nginx:1.16",
 						},


### PR DESCRIPTION
Fixes #888

Had to reorder the args a little because `--skip-update` belongs to the
image subcommand now