### PR TITLE
feat: add pod template labels to scanJob

### DIFF
--- a/deploy/helm/templates/config.yaml
+++ b/deploy/helm/templates/config.yaml
@@ -12,8 +12,8 @@ data:
   {{- with .Values.starboard.scanJobAnnotations }}
   scanJob.annotations: {{ . | quote }}
   {{- end }}
-  {{- with .Values.starboard.scanJobTemplateLabels }}
-  scanJob.templateLabels: {{ . | quote }}
+  {{- with .Values.starboard.scanJobPodTemplateLabels }}
+  scanJob.podTemplateLabels: {{ . | quote }}
   {{- end }}
   {{- if .Values.operator.vulnerabilityScannerEnabled }}
   vulnerabilityReports.scanner: {{ .Values.starboard.vulnerabilityReportsPlugin | quote }}

--- a/deploy/helm/templates/config.yaml
+++ b/deploy/helm/templates/config.yaml
@@ -12,6 +12,9 @@ data:
   {{- with .Values.starboard.scanJobAnnotations }}
   scanJob.annotations: {{ . | quote }}
   {{- end }}
+  {{- with .Values.starboard.scanJobTemplateLabels }}
+  scanJob.templateLabels: {{ . | quote }}
+  {{- end }}
   {{- if .Values.operator.vulnerabilityScannerEnabled }}
   vulnerabilityReports.scanner: {{ .Values.starboard.vulnerabilityReportsPlugin | quote }}
   {{- end }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -83,6 +83,10 @@ starboard:
   # annotated with. Example: `foo=bar,env=stage` will annotate the scanner pods with the annotations `foo: bar` and `env: stage`
   scanJobAnnotations: ""
 
+  # scanJobTemplateLabels comma-separated representation of the labels which the user wants the scanner pods to be
+  # labeled with. Example: `foo=bar,env=stage` will labeled the scanner pods with the labels `foo: bar` and `env: stage`
+  scanJobTemplateLabels: ""
+
 trivy:
   # createConfig indicates whether to create config objects
   createConfig: true

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -83,9 +83,9 @@ starboard:
   # annotated with. Example: `foo=bar,env=stage` will annotate the scanner pods with the annotations `foo: bar` and `env: stage`
   scanJobAnnotations: ""
 
-  # scanJobTemplateLabels comma-separated representation of the labels which the user wants the scanner pods to be
+  # scanJobPodTemplateLabels comma-separated representation of the labels which the user wants the scanner pods to be
   # labeled with. Example: `foo=bar,env=stage` will labeled the scanner pods with the labels `foo: bar` and `env: stage`
-  scanJobTemplateLabels: ""
+  scanJobPodTemplateLabels: ""
 
 trivy:
   # createConfig indicates whether to create config objects

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -58,6 +58,7 @@ configuration settings for common use cases. For example, switch Trivy from [Sta
 | `configAuditReports.scanner`   | `Polaris`                             | The name of the plugin that generates config audit reports. Either `Polaris` or `Conftest`. |
 | `scanJob.tolerations`          | N/A                                   | JSON representation of the [tolerations] to be applied to the scanner pods so that they can run on nodes with matching taints. Example: `'[{"key":"key1", "operator":"Equal", "value":"value1", "effect":"NoSchedule"}]'` |
 | `scanJob.annotations`          | N/A                                   | One-line comma-separated representation of the annotations which the user wants the scanner pods to be annotated with. Example: `foo=bar,env=stage` will annotate the scanner pods with the annotations `foo: bar` and `env: stage` |
+| `scanJob.templateLabel`        | N/A                                   | One-line comma-separated representation of the template labels which the user wants the scanner pods to be labeled with. Example: `foo=bar,env=stage` will labeled the scanner pods with the labels `foo: bar` and `env: stage` |
 | `kube-bench.imageRef`          | `docker.io/aquasec/kube-bench:v0.6.5`  | kube-bench image reference |
 | `kube-hunter.imageRef`         | `docker.io/aquasec/kube-hunter:0.6.3` | kube-hunter image reference |
 | `kube-hunter.quick`            | `"false"`                             | Whether to use kube-hunter's "quick" scanning mode (subnet 24). Set to `"true"` to enable. |

--- a/pkg/configauditreport/builder.go
+++ b/pkg/configauditreport/builder.go
@@ -21,13 +21,13 @@ import (
 )
 
 type ScanJobBuilder struct {
-	plugin         Plugin
-	pluginContext  starboard.PluginContext
-	timeout        time.Duration
-	object         client.Object
-	tolerations    []corev1.Toleration
-	annotations    map[string]string
-	templateLabels labels.Set
+	plugin            Plugin
+	pluginContext     starboard.PluginContext
+	timeout           time.Duration
+	object            client.Object
+	tolerations       []corev1.Toleration
+	annotations       map[string]string
+	podTemplateLabels labels.Set
 }
 
 func NewScanJobBuilder() *ScanJobBuilder {
@@ -64,8 +64,8 @@ func (s *ScanJobBuilder) WithAnnotations(annotations map[string]string) *ScanJob
 	return s
 }
 
-func (s *ScanJobBuilder) WithTemplateLabels(templateLabels labels.Set) *ScanJobBuilder {
-	s.templateLabels = templateLabels
+func (s *ScanJobBuilder) WithPodTemplateLabels(podTemplateLabels labels.Set) *ScanJobBuilder {
+	s.podTemplateLabels = podTemplateLabels
 	return s
 }
 
@@ -94,12 +94,12 @@ func (s *ScanJobBuilder) Get() (*batchv1.Job, []*corev1.Secret, error) {
 		starboard.LabelK8SAppManagedBy:          starboard.AppStarboard,
 	}
 
-	templateLabelsSet := make(labels.Set)
+	podTemplateLabelsSet := make(labels.Set)
 	for index, element := range labelsSet {
-		templateLabelsSet[index] = element
+		podTemplateLabelsSet[index] = element
 	}
-	for index, element := range s.templateLabels {
-		templateLabelsSet[index] = element
+	for index, element := range s.podTemplateLabels {
+		podTemplateLabelsSet[index] = element
 	}
 
 	job := &batchv1.Job{
@@ -115,7 +115,7 @@ func (s *ScanJobBuilder) Get() (*batchv1.Job, []*corev1.Secret, error) {
 			ActiveDeadlineSeconds: kube.GetActiveDeadlineSeconds(s.timeout),
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels:      templateLabelsSet,
+					Labels:      podTemplateLabelsSet,
 					Annotations: s.annotations,
 				},
 				Spec: jobSpec,

--- a/pkg/configauditreport/scanner.go
+++ b/pkg/configauditreport/scanner.go
@@ -77,6 +77,11 @@ func (s *Scanner) Scan(ctx context.Context, partial kube.ObjectRef) (*ReportBuil
 		return nil, fmt.Errorf("getting scan job annotations: %w", err)
 	}
 
+	scanJobTemplateLabels, err := s.config.GetScanJobTemplateLabels()
+	if err != nil {
+		return nil, fmt.Errorf("getting scan job template labels: %w", err)
+	}
+
 	klog.V(3).Infof("Scanning with options: %+v", s.opts)
 	job, secrets, err := NewScanJobBuilder().
 		WithPlugin(s.plugin).
@@ -85,6 +90,7 @@ func (s *Scanner) Scan(ctx context.Context, partial kube.ObjectRef) (*ReportBuil
 		WithObject(owner).
 		WithTolerations(scanJobTolerations).
 		WithAnnotations(scanJobAnnotations).
+		WithTemplateLabels(scanJobTemplateLabels).
 		Get()
 	if err != nil {
 		return nil, fmt.Errorf("constructing scan job: %w", err)

--- a/pkg/configauditreport/scanner.go
+++ b/pkg/configauditreport/scanner.go
@@ -77,7 +77,7 @@ func (s *Scanner) Scan(ctx context.Context, partial kube.ObjectRef) (*ReportBuil
 		return nil, fmt.Errorf("getting scan job annotations: %w", err)
 	}
 
-	scanJobTemplateLabels, err := s.config.GetScanJobTemplateLabels()
+	scanJobPodTemplateLabels, err := s.config.GetScanJobPodTemplateLabels()
 	if err != nil {
 		return nil, fmt.Errorf("getting scan job template labels: %w", err)
 	}
@@ -90,7 +90,7 @@ func (s *Scanner) Scan(ctx context.Context, partial kube.ObjectRef) (*ReportBuil
 		WithObject(owner).
 		WithTolerations(scanJobTolerations).
 		WithAnnotations(scanJobAnnotations).
-		WithTemplateLabels(scanJobTemplateLabels).
+		WithPodTemplateLabels(scanJobPodTemplateLabels).
 		Get()
 	if err != nil {
 		return nil, fmt.Errorf("constructing scan job: %w", err)

--- a/pkg/kubebench/scanner.go
+++ b/pkg/kubebench/scanner.go
@@ -120,14 +120,29 @@ func (s *Scanner) prepareKubeBenchJob(node corev1.Node) (*batchv1.Job, error) {
 		return nil, err
 	}
 
+	scanJobTemplateLabels, err := s.config.GetScanJobTemplateLabels()
+	if err != nil {
+		return nil, err
+	}
+
+	labelsSet := labels.Set{
+		starboard.LabelResourceKind: string(kube.KindNode),
+		starboard.LabelResourceName: node.Name,
+	}
+
+	templateLabelsSet := make(labels.Set)
+	for index, element := range labelsSet {
+		templateLabelsSet[index] = element
+	}
+	for index, element := range scanJobTemplateLabels {
+		templateLabelsSet[index] = element
+	}
+
 	return &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "scan-cisbenchmark-" + kube.ComputeHash(node.Name),
 			Namespace: starboard.NamespaceName,
-			Labels: labels.Set{
-				starboard.LabelResourceKind: string(kube.KindNode),
-				starboard.LabelResourceName: node.Name,
-			},
+			Labels:    labelsSet,
 		},
 		Spec: batchv1.JobSpec{
 			BackoffLimit:          pointer.Int32Ptr(0),
@@ -135,10 +150,7 @@ func (s *Scanner) prepareKubeBenchJob(node corev1.Node) (*batchv1.Job, error) {
 			ActiveDeadlineSeconds: kube.GetActiveDeadlineSeconds(s.opts.ScanJobTimeout),
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: labels.Set{
-						starboard.LabelResourceKind: string(kube.KindNode),
-						starboard.LabelResourceName: node.Name,
-					},
+					Labels:      templateLabelsSet,
 					Annotations: scanJobAnnotations,
 				},
 				Spec: templateSpec,

--- a/pkg/kubebench/scanner.go
+++ b/pkg/kubebench/scanner.go
@@ -120,7 +120,7 @@ func (s *Scanner) prepareKubeBenchJob(node corev1.Node) (*batchv1.Job, error) {
 		return nil, err
 	}
 
-	scanJobTemplateLabels, err := s.config.GetScanJobTemplateLabels()
+	scanJobPodTemplateLabels, err := s.config.GetScanJobPodTemplateLabels()
 	if err != nil {
 		return nil, err
 	}
@@ -130,12 +130,12 @@ func (s *Scanner) prepareKubeBenchJob(node corev1.Node) (*batchv1.Job, error) {
 		starboard.LabelResourceName: node.Name,
 	}
 
-	templateLabelsSet := make(labels.Set)
+	podTemplateLabelsSet := make(labels.Set)
 	for index, element := range labelsSet {
-		templateLabelsSet[index] = element
+		podTemplateLabelsSet[index] = element
 	}
-	for index, element := range scanJobTemplateLabels {
-		templateLabelsSet[index] = element
+	for index, element := range scanJobPodTemplateLabels {
+		podTemplateLabelsSet[index] = element
 	}
 
 	return &batchv1.Job{
@@ -150,7 +150,7 @@ func (s *Scanner) prepareKubeBenchJob(node corev1.Node) (*batchv1.Job, error) {
 			ActiveDeadlineSeconds: kube.GetActiveDeadlineSeconds(s.opts.ScanJobTimeout),
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels:      templateLabelsSet,
+					Labels:      podTemplateLabelsSet,
 					Annotations: scanJobAnnotations,
 				},
 				Spec: templateSpec,

--- a/pkg/kubehunter/scanner.go
+++ b/pkg/kubehunter/scanner.go
@@ -117,6 +117,11 @@ func (s *Scanner) prepareKubeHunterJob() (*batchv1.Job, error) {
 		return nil, err
 	}
 
+	scanJobTemplateLabels, err := s.config.GetScanJobTemplateLabels()
+	if err != nil {
+		return nil, err
+	}
+
 	var (
 		podSecurityContext       *corev1.PodSecurityContext
 		containerSecurityContext *corev1.SecurityContext
@@ -156,6 +161,7 @@ func (s *Scanner) prepareKubeHunterJob() (*batchv1.Job, error) {
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: scanJobAnnotations,
+					Labels:      scanJobTemplateLabels,
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName: starboard.ServiceAccountName,

--- a/pkg/kubehunter/scanner.go
+++ b/pkg/kubehunter/scanner.go
@@ -117,7 +117,7 @@ func (s *Scanner) prepareKubeHunterJob() (*batchv1.Job, error) {
 		return nil, err
 	}
 
-	scanJobTemplateLabels, err := s.config.GetScanJobTemplateLabels()
+	scanJobPodTemplateLabels, err := s.config.GetScanJobPodTemplateLabels()
 	if err != nil {
 		return nil, err
 	}
@@ -161,7 +161,7 @@ func (s *Scanner) prepareKubeHunterJob() (*batchv1.Job, error) {
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: scanJobAnnotations,
-					Labels:      scanJobTemplateLabels,
+					Labels:      scanJobPodTemplateLabels,
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName: starboard.ServiceAccountName,

--- a/pkg/operator/controller/ciskubebenchreport.go
+++ b/pkg/operator/controller/ciskubebenchreport.go
@@ -169,7 +169,7 @@ func (r *CISKubeBenchReportReconciler) newScanJob(node *corev1.Node) (*batchv1.J
 		return nil, err
 	}
 
-	scanJobTemplateLabels, err := r.ConfigData.GetScanJobTemplateLabels()
+	scanJobPodTemplateLabels, err := r.ConfigData.GetScanJobPodTemplateLabels()
 	if err != nil {
 		return nil, err
 	}
@@ -181,12 +181,12 @@ func (r *CISKubeBenchReportReconciler) newScanJob(node *corev1.Node) (*batchv1.J
 		starboard.LabelKubeBenchReportScanner: "true",
 	}
 
-	templateLabelsSet := make(labels.Set)
+	podTemplateLabelsSet := make(labels.Set)
 	for index, element := range labelsSet {
-		templateLabelsSet[index] = element
+		podTemplateLabelsSet[index] = element
 	}
-	for index, element := range scanJobTemplateLabels {
-		templateLabelsSet[index] = element
+	for index, element := range scanJobPodTemplateLabels {
+		podTemplateLabelsSet[index] = element
 	}
 
 	return &batchv1.Job{
@@ -201,7 +201,7 @@ func (r *CISKubeBenchReportReconciler) newScanJob(node *corev1.Node) (*batchv1.J
 			ActiveDeadlineSeconds: kube.GetActiveDeadlineSeconds(r.Config.ScanJobTimeout),
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels:      templateLabelsSet,
+					Labels:      podTemplateLabelsSet,
 					Annotations: scanJobAnnotations,
 				},
 				Spec: templateSpec,

--- a/pkg/operator/controller/ciskubebenchreport.go
+++ b/pkg/operator/controller/ciskubebenchreport.go
@@ -169,16 +169,31 @@ func (r *CISKubeBenchReportReconciler) newScanJob(node *corev1.Node) (*batchv1.J
 		return nil, err
 	}
 
+	scanJobTemplateLabels, err := r.ConfigData.GetScanJobTemplateLabels()
+	if err != nil {
+		return nil, err
+	}
+
+	labelsSet := labels.Set{
+		starboard.LabelResourceKind:           string(kube.KindNode),
+		starboard.LabelResourceName:           node.Name,
+		starboard.LabelK8SAppManagedBy:        starboard.AppStarboard,
+		starboard.LabelKubeBenchReportScanner: "true",
+	}
+
+	templateLabelsSet := make(labels.Set)
+	for index, element := range labelsSet {
+		templateLabelsSet[index] = element
+	}
+	for index, element := range scanJobTemplateLabels {
+		templateLabelsSet[index] = element
+	}
+
 	return &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      r.getScanJobName(node),
 			Namespace: r.Config.Namespace,
-			Labels: labels.Set{
-				starboard.LabelResourceKind:           string(kube.KindNode),
-				starboard.LabelResourceName:           node.Name,
-				starboard.LabelK8SAppManagedBy:        starboard.AppStarboard,
-				starboard.LabelKubeBenchReportScanner: "true",
-			},
+			Labels:    labelsSet,
 		},
 		Spec: batchv1.JobSpec{
 			BackoffLimit:          pointer.Int32Ptr(0),
@@ -186,12 +201,7 @@ func (r *CISKubeBenchReportReconciler) newScanJob(node *corev1.Node) (*batchv1.J
 			ActiveDeadlineSeconds: kube.GetActiveDeadlineSeconds(r.Config.ScanJobTimeout),
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: labels.Set{
-						starboard.LabelResourceKind:           string(kube.KindNode),
-						starboard.LabelResourceName:           node.Name,
-						starboard.LabelK8SAppManagedBy:        starboard.AppStarboard,
-						starboard.LabelKubeBenchReportScanner: "true",
-					},
+					Labels:      templateLabelsSet,
 					Annotations: scanJobAnnotations,
 				},
 				Spec: templateSpec,

--- a/pkg/operator/controller/configauditreport.go
+++ b/pkg/operator/controller/configauditreport.go
@@ -237,6 +237,11 @@ func (r *ConfigAuditReportReconciler) reconcileResource(resourceKind kube.Kind) 
 			return ctrl.Result{}, fmt.Errorf("getting scan job annotations: %w", err)
 		}
 
+		scanJobTemplateLabels, err := r.GetScanJobTemplateLabels()
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("getting scan job template labels: %w", err)
+		}
+
 		job, secrets, err := configauditreport.NewScanJobBuilder().
 			WithPlugin(r.Plugin).
 			WithPluginContext(r.PluginContext).
@@ -244,6 +249,7 @@ func (r *ConfigAuditReportReconciler) reconcileResource(resourceKind kube.Kind) 
 			WithObject(resource).
 			WithTolerations(scanJobTolerations).
 			WithAnnotations(scanJobAnnotations).
+			WithTemplateLabels(scanJobTemplateLabels).
 			Get()
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("constructing scan job: %w", err)

--- a/pkg/operator/controller/configauditreport.go
+++ b/pkg/operator/controller/configauditreport.go
@@ -237,7 +237,7 @@ func (r *ConfigAuditReportReconciler) reconcileResource(resourceKind kube.Kind) 
 			return ctrl.Result{}, fmt.Errorf("getting scan job annotations: %w", err)
 		}
 
-		scanJobTemplateLabels, err := r.GetScanJobTemplateLabels()
+		scanJobPodTemplateLabels, err := r.GetScanJobPodTemplateLabels()
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("getting scan job template labels: %w", err)
 		}
@@ -249,7 +249,7 @@ func (r *ConfigAuditReportReconciler) reconcileResource(resourceKind kube.Kind) 
 			WithObject(resource).
 			WithTolerations(scanJobTolerations).
 			WithAnnotations(scanJobAnnotations).
-			WithTemplateLabels(scanJobTemplateLabels).
+			WithPodTemplateLabels(scanJobPodTemplateLabels).
 			Get()
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("constructing scan job: %w", err)

--- a/pkg/operator/controller/vulnerabilityreport.go
+++ b/pkg/operator/controller/vulnerabilityreport.go
@@ -232,7 +232,7 @@ func (r *VulnerabilityReportReconciler) submitScanJob(ctx context.Context, owner
 		return fmt.Errorf("getting scan job annotations: %w", err)
 	}
 
-	scanJobTemplateLabels, err := r.GetScanJobTemplateLabels()
+	scanJobPodTemplateLabels, err := r.GetScanJobPodTemplateLabels()
 	if err != nil {
 		return fmt.Errorf("getting scan job template labels: %w", err)
 	}
@@ -244,7 +244,7 @@ func (r *VulnerabilityReportReconciler) submitScanJob(ctx context.Context, owner
 		WithObject(owner).
 		WithTolerations(scanJobTolerations).
 		WithAnnotations(scanJobAnnotations).
-		WithTemplateLabels(scanJobTemplateLabels).
+		WithPodTemplateLabels(scanJobPodTemplateLabels).
 		WithCredentials(credentials).
 		Get()
 

--- a/pkg/operator/controller/vulnerabilityreport.go
+++ b/pkg/operator/controller/vulnerabilityreport.go
@@ -232,6 +232,11 @@ func (r *VulnerabilityReportReconciler) submitScanJob(ctx context.Context, owner
 		return fmt.Errorf("getting scan job annotations: %w", err)
 	}
 
+	scanJobTemplateLabels, err := r.GetScanJobTemplateLabels()
+	if err != nil {
+		return fmt.Errorf("getting scan job template labels: %w", err)
+	}
+
 	scanJob, secrets, err := vulnerabilityreport.NewScanJobBuilder().
 		WithPlugin(r.Plugin).
 		WithPluginContext(r.PluginContext).
@@ -239,6 +244,7 @@ func (r *VulnerabilityReportReconciler) submitScanJob(ctx context.Context, owner
 		WithObject(owner).
 		WithTolerations(scanJobTolerations).
 		WithAnnotations(scanJobAnnotations).
+		WithTemplateLabels(scanJobTemplateLabels).
 		WithCredentials(credentials).
 		Get()
 

--- a/pkg/starboard/config.go
+++ b/pkg/starboard/config.go
@@ -146,23 +146,23 @@ func (c ConfigData) GetScanJobAnnotations() (map[string]string, error) {
 	return scanJobAnnotationsMap, nil
 }
 
-func (c ConfigData) GetScanJobTemplateLabels() (labels.Set, error) {
-	scanJobTemplateLabelsStr, found := c[AnnotationScanJobTemplateLabels]
-	if !found || strings.TrimSpace(scanJobTemplateLabelsStr) == "" {
+func (c ConfigData) GetScanJobPodTemplateLabels() (labels.Set, error) {
+	scanJobPodTemplateLabelsStr, found := c[AnnotationScanJobPodTemplateLabels]
+	if !found || strings.TrimSpace(scanJobPodTemplateLabelsStr) == "" {
 		return labels.Set{}, nil
 	}
 
-	scanJobTemplateLabelsMap := map[string]string{}
-	for _, annotation := range strings.Split(scanJobTemplateLabelsStr, ",") {
+	scanJobPodTemplateLabelsMap := map[string]string{}
+	for _, annotation := range strings.Split(scanJobPodTemplateLabelsStr, ",") {
 		sepByEqual := strings.Split(annotation, "=")
 		if len(sepByEqual) != 2 {
-			return labels.Set{}, fmt.Errorf("custom template labels found to be wrongfully provided: %s", scanJobTemplateLabelsStr)
+			return labels.Set{}, fmt.Errorf("custom template labels found to be wrongfully provided: %s", scanJobPodTemplateLabelsStr)
 		}
 		key, value := sepByEqual[0], sepByEqual[1]
-		scanJobTemplateLabelsMap[key] = value
+		scanJobPodTemplateLabelsMap[key] = value
 	}
 
-	return scanJobTemplateLabelsMap, nil
+	return scanJobPodTemplateLabelsMap, nil
 }
 
 func (c ConfigData) GetKubeBenchImageRef() (string, error) {

--- a/pkg/starboard/config.go
+++ b/pkg/starboard/config.go
@@ -146,6 +146,25 @@ func (c ConfigData) GetScanJobAnnotations() (map[string]string, error) {
 	return scanJobAnnotationsMap, nil
 }
 
+func (c ConfigData) GetScanJobTemplateLabels() (labels.Set, error) {
+	scanJobTemplateLabelsStr, found := c[AnnotationScanJobTemplateLabels]
+	if !found || strings.TrimSpace(scanJobTemplateLabelsStr) == "" {
+		return labels.Set{}, nil
+	}
+
+	scanJobTemplateLabelsMap := map[string]string{}
+	for _, annotation := range strings.Split(scanJobTemplateLabelsStr, ",") {
+		sepByEqual := strings.Split(annotation, "=")
+		if len(sepByEqual) != 2 {
+			return labels.Set{}, fmt.Errorf("custom template labels found to be wrongfully provided: %s", scanJobTemplateLabelsStr)
+		}
+		key, value := sepByEqual[0], sepByEqual[1]
+		scanJobTemplateLabelsMap[key] = value
+	}
+
+	return scanJobTemplateLabelsMap, nil
+}
+
 func (c ConfigData) GetKubeBenchImageRef() (string, error) {
 	return c.GetRequiredData("kube-bench.imageRef")
 }

--- a/pkg/starboard/config_test.go
+++ b/pkg/starboard/config_test.go
@@ -496,7 +496,7 @@ func TestGetScanJobAnnotations(t *testing.T) {
 	}
 }
 
-func TestGetScanJobTemplateLabels(t *testing.T) {
+func TestGetScanJobPodTemplateLabels(t *testing.T) {
 	testCases := []struct {
 		name        string
 		config      starboard.ConfigData
@@ -506,7 +506,7 @@ func TestGetScanJobTemplateLabels(t *testing.T) {
 		{
 			name: "scan job template labels can be fetched successfully",
 			config: starboard.ConfigData{
-				"scanJob.templateLabels": "a.b=c.d/e,foo=bar",
+				"scanJob.podTemplateLabels": "a.b=c.d/e,foo=bar",
 			},
 			expected: labels.Set{
 				"foo": "bar",
@@ -521,7 +521,7 @@ func TestGetScanJobTemplateLabels(t *testing.T) {
 		{
 			name: "raise an error on being provided with annotations in wrong format",
 			config: starboard.ConfigData{
-				"scanJob.templateLabels": "foo",
+				"scanJob.podTemplateLabels": "foo",
 			},
 			expected:    labels.Set{},
 			expectError: "custom template labels found to be wrongfully provided: foo",
@@ -529,7 +529,7 @@ func TestGetScanJobTemplateLabels(t *testing.T) {
 		{
 			name: "raise an error on being provided with template labels in wrong format",
 			config: starboard.ConfigData{
-				"scanJob.templateLabels": "foo=bar,a=b=c",
+				"scanJob.podTemplateLabels": "foo=bar,a=b=c",
 			},
 			expected:    labels.Set{},
 			expectError: "custom template labels found to be wrongfully provided: foo=bar,a=b=c",
@@ -538,13 +538,13 @@ func TestGetScanJobTemplateLabels(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			scanJobTemplateLabels, err := tc.config.GetScanJobTemplateLabels()
+			scanJobPodTemplateLabels, err := tc.config.GetScanJobPodTemplateLabels()
 			if tc.expectError != "" {
 				assert.Error(t, err, tc.expectError, tc.name)
 			} else {
 				assert.NoError(t, err, tc.name)
 			}
-			assert.Equal(t, tc.expected, scanJobTemplateLabels, tc.name)
+			assert.Equal(t, tc.expected, scanJobPodTemplateLabels, tc.name)
 		})
 	}
 }

--- a/pkg/starboard/constants.go
+++ b/pkg/starboard/constants.go
@@ -42,6 +42,7 @@ const (
 )
 
 const (
-	AnnotationContainerImages    = "starboard.container-images"
-	AnnotationScanJobAnnotations = "scanJob.annotations"
+	AnnotationContainerImages       = "starboard.container-images"
+	AnnotationScanJobAnnotations    = "scanJob.annotations"
+	AnnotationScanJobTemplateLabels = "scanJob.templateLabels"
 )

--- a/pkg/starboard/constants.go
+++ b/pkg/starboard/constants.go
@@ -42,7 +42,7 @@ const (
 )
 
 const (
-	AnnotationContainerImages       = "starboard.container-images"
-	AnnotationScanJobAnnotations    = "scanJob.annotations"
-	AnnotationScanJobTemplateLabels = "scanJob.templateLabels"
+	AnnotationContainerImages          = "starboard.container-images"
+	AnnotationScanJobAnnotations       = "scanJob.annotations"
+	AnnotationScanJobPodTemplateLabels = "scanJob.podTemplateLabels"
 )

--- a/pkg/vulnerabilityreport/builder.go
+++ b/pkg/vulnerabilityreport/builder.go
@@ -12,6 +12,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/utils/pointer"
@@ -20,13 +21,14 @@ import (
 )
 
 type ScanJobBuilder struct {
-	plugin        Plugin
-	pluginContext starboard.PluginContext
-	timeout       time.Duration
-	object        client.Object
-	credentials   map[string]docker.Auth
-	tolerations   []corev1.Toleration
-	annotations   map[string]string
+	plugin         Plugin
+	pluginContext  starboard.PluginContext
+	timeout        time.Duration
+	object         client.Object
+	credentials    map[string]docker.Auth
+	tolerations    []corev1.Toleration
+	annotations    map[string]string
+	templateLabels labels.Set
 }
 
 func NewScanJobBuilder() *ScanJobBuilder {
@@ -63,6 +65,11 @@ func (s *ScanJobBuilder) WithAnnotations(annotations map[string]string) *ScanJob
 	return s
 }
 
+func (s *ScanJobBuilder) WithTemplateLabels(templateLabels labels.Set) *ScanJobBuilder {
+	s.templateLabels = templateLabels
+	return s
+}
+
 func (s *ScanJobBuilder) WithCredentials(credentials map[string]docker.Auth) *ScanJobBuilder {
 	s.credentials = credentials
 	return s
@@ -87,17 +94,24 @@ func (s *ScanJobBuilder) Get() (*batchv1.Job, []*corev1.Secret, error) {
 
 	podSpecHash := kube.ComputeHash(spec)
 
-	labels := map[string]string{
+	labelsSet := map[string]string{
 		starboard.LabelResourceSpecHash:           podSpecHash,
 		starboard.LabelK8SAppManagedBy:            starboard.AppStarboard,
 		starboard.LabelVulnerabilityReportScanner: s.pluginContext.GetName(),
+	}
+	templateLabelsSet := make(labels.Set)
+	for index, element := range labelsSet {
+		templateLabelsSet[index] = element
+	}
+	for index, element := range s.templateLabels {
+		templateLabelsSet[index] = element
 	}
 
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      GetScanJobName(s.object),
 			Namespace: s.pluginContext.GetNamespace(),
-			Labels:    labels,
+			Labels:    labelsSet,
 			Annotations: map[string]string{
 				starboard.AnnotationContainerImages: containerImagesAsJSON,
 			},
@@ -108,7 +122,7 @@ func (s *ScanJobBuilder) Get() (*batchv1.Job, []*corev1.Secret, error) {
 			ActiveDeadlineSeconds: kube.GetActiveDeadlineSeconds(s.timeout),
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels:      labels,
+					Labels:      templateLabelsSet,
 					Annotations: s.annotations,
 				},
 				Spec: templateSpec,

--- a/pkg/vulnerabilityreport/builder.go
+++ b/pkg/vulnerabilityreport/builder.go
@@ -21,14 +21,14 @@ import (
 )
 
 type ScanJobBuilder struct {
-	plugin         Plugin
-	pluginContext  starboard.PluginContext
-	timeout        time.Duration
-	object         client.Object
-	credentials    map[string]docker.Auth
-	tolerations    []corev1.Toleration
-	annotations    map[string]string
-	templateLabels labels.Set
+	plugin            Plugin
+	pluginContext     starboard.PluginContext
+	timeout           time.Duration
+	object            client.Object
+	credentials       map[string]docker.Auth
+	tolerations       []corev1.Toleration
+	annotations       map[string]string
+	podTemplateLabels labels.Set
 }
 
 func NewScanJobBuilder() *ScanJobBuilder {
@@ -65,8 +65,8 @@ func (s *ScanJobBuilder) WithAnnotations(annotations map[string]string) *ScanJob
 	return s
 }
 
-func (s *ScanJobBuilder) WithTemplateLabels(templateLabels labels.Set) *ScanJobBuilder {
-	s.templateLabels = templateLabels
+func (s *ScanJobBuilder) WithPodTemplateLabels(podTemplateLabels labels.Set) *ScanJobBuilder {
+	s.podTemplateLabels = podTemplateLabels
 	return s
 }
 
@@ -99,12 +99,12 @@ func (s *ScanJobBuilder) Get() (*batchv1.Job, []*corev1.Secret, error) {
 		starboard.LabelK8SAppManagedBy:            starboard.AppStarboard,
 		starboard.LabelVulnerabilityReportScanner: s.pluginContext.GetName(),
 	}
-	templateLabelsSet := make(labels.Set)
+	podTemplateLabelsSet := make(labels.Set)
 	for index, element := range labelsSet {
-		templateLabelsSet[index] = element
+		podTemplateLabelsSet[index] = element
 	}
-	for index, element := range s.templateLabels {
-		templateLabelsSet[index] = element
+	for index, element := range s.podTemplateLabels {
+		podTemplateLabelsSet[index] = element
 	}
 
 	job := &batchv1.Job{
@@ -122,7 +122,7 @@ func (s *ScanJobBuilder) Get() (*batchv1.Job, []*corev1.Secret, error) {
 			ActiveDeadlineSeconds: kube.GetActiveDeadlineSeconds(s.timeout),
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels:      templateLabelsSet,
+					Labels:      podTemplateLabelsSet,
 					Annotations: s.annotations,
 				},
 				Spec: templateSpec,

--- a/pkg/vulnerabilityreport/scanner.go
+++ b/pkg/vulnerabilityreport/scanner.go
@@ -84,6 +84,11 @@ func (s *Scanner) Scan(ctx context.Context, workload kube.ObjectRef) ([]v1alpha1
 		return nil, fmt.Errorf("getting scan job annotations: %w", err)
 	}
 
+	scanJobTemplateLabels, err := s.config.GetScanJobTemplateLabels()
+	if err != nil {
+		return nil, fmt.Errorf("getting scan job template labels: %w", err)
+	}
+
 	klog.V(3).Infof("Scanning with options: %+v", s.opts)
 
 	credentials, err := s.secretsReader.CredentialsByWorkload(ctx, owner)
@@ -99,6 +104,7 @@ func (s *Scanner) Scan(ctx context.Context, workload kube.ObjectRef) ([]v1alpha1
 		WithCredentials(credentials).
 		WithTolerations(scanJobTolerations).
 		WithAnnotations(scanJobAnnotations).
+		WithTemplateLabels(scanJobTemplateLabels).
 		Get()
 
 	if err != nil {

--- a/pkg/vulnerabilityreport/scanner.go
+++ b/pkg/vulnerabilityreport/scanner.go
@@ -84,7 +84,7 @@ func (s *Scanner) Scan(ctx context.Context, workload kube.ObjectRef) ([]v1alpha1
 		return nil, fmt.Errorf("getting scan job annotations: %w", err)
 	}
 
-	scanJobTemplateLabels, err := s.config.GetScanJobTemplateLabels()
+	scanJobPodTemplateLabels, err := s.config.GetScanJobPodTemplateLabels()
 	if err != nil {
 		return nil, fmt.Errorf("getting scan job template labels: %w", err)
 	}
@@ -104,7 +104,7 @@ func (s *Scanner) Scan(ctx context.Context, workload kube.ObjectRef) ([]v1alpha1
 		WithCredentials(credentials).
 		WithTolerations(scanJobTolerations).
 		WithAnnotations(scanJobAnnotations).
-		WithTemplateLabels(scanJobTemplateLabels).
+		WithPodTemplateLabels(scanJobPodTemplateLabels).
 		Get()
 
 	if err != nil {


### PR DESCRIPTION
This is the preparation for the use of starboard together with https://github.com/Azure/aad-pod-identity. This is necessary to support Azure Acr #278.

also this https://github.com/aquasecurity/fanal/pull/371 is needed  to allow trivy to pull from acr.