### PR TITLE
feat: Add option to run Vuln scan job in worload namespace

### DIFF
--- a/docs/design/design_vuln_scan_job_in_same_namespace_of_workload.md
+++ b/docs/design/design_vuln_scan_job_in_same_namespace_of_workload.md
@@ -23,9 +23,9 @@ we cannot reuse the same ImagePullSecret available on the workload.
 
 ## Solution
 
-Add an environment variable to operator eg `OPERATOR_VULNERABILITY_SCANNER_SAME_NAMESPACE=true`. This way operator can schedule
-and monitor scan jobs in same namespace where workload is running. And plugins will act accordingly to utilize the service 
-account and ImagePullSecret available on the workload.
+Consider there is an option given to enable running vulnerability scan jobs in the same namespace of workload. Operator
+detects it, so it can schedule and monitor scan jobs in same namespace where workload is running. And plugins will act 
+accordingly to utilize the service account and ImagePullSecret available on the workload.
 
 
 ### Example

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -52,16 +52,17 @@ EOF
 The following table lists available settings with their default values. Check plugins' documentation to see
 configuration settings for common use cases. For example, switch Trivy from [Standalone] to [ClientServer] mode.
 
-| CONFIGMAP KEY                  | DEFAULT                               | DESCRIPTION |
-| ------------------------------ | ------------------------------------- | ----------- |
-| `vulnerabilityReports.scanner` | `Trivy`                               | The name of the plugin that generates vulnerability reports. Either `Trivy` or `Aqua`. |
-| `configAuditReports.scanner`   | `Polaris`                             | The name of the plugin that generates config audit reports. Either `Polaris` or `Conftest`. |
-| `scanJob.tolerations`          | N/A                                   | JSON representation of the [tolerations] to be applied to the scanner pods so that they can run on nodes with matching taints. Example: `'[{"key":"key1", "operator":"Equal", "value":"value1", "effect":"NoSchedule"}]'` |
-| `scanJob.annotations`          | N/A                                   | One-line comma-separated representation of the annotations which the user wants the scanner pods to be annotated with. Example: `foo=bar,env=stage` will annotate the scanner pods with the annotations `foo: bar` and `env: stage` |
-| `scanJob.templateLabel`        | N/A                                   | One-line comma-separated representation of the template labels which the user wants the scanner pods to be labeled with. Example: `foo=bar,env=stage` will labeled the scanner pods with the labels `foo: bar` and `env: stage` |
-| `kube-bench.imageRef`          | `docker.io/aquasec/kube-bench:v0.6.5`  | kube-bench image reference |
-| `kube-hunter.imageRef`         | `docker.io/aquasec/kube-hunter:0.6.3` | kube-hunter image reference |
-| `kube-hunter.quick`            | `"false"`                             | Whether to use kube-hunter's "quick" scanning mode (subnet 24). Set to `"true"` to enable. |
+| CONFIGMAP KEY                                 | DEFAULT                               | DESCRIPTION |
+| --------------------------------------------- | ------------------------------------- | ----------- |
+| `vulnerabilityReports.scanner`                | `Trivy`                               | The name of the plugin that generates vulnerability reports. Either `Trivy` or `Aqua`. |
+| `vulnerabilityReports.scanJobsInSameNamespace`| `"false"`                             | Whether to run vulnerability scan jobs in same namespace of workload. Set `"true"` to enable. |
+| `configAuditReports.scanner`                  | `Polaris`                             | The name of the plugin that generates config audit reports. Either `Polaris` or `Conftest`. |
+| `scanJob.tolerations`                         | N/A                                   | JSON representation of the [tolerations] to be applied to the scanner pods so that they can run on nodes with matching taints. Example: `'[{"key":"key1", "operator":"Equal", "value":"value1", "effect":"NoSchedule"}]'` |
+| `scanJob.annotations`                         | N/A                                   | One-line comma-separated representation of the annotations which the user wants the scanner pods to be annotated with. Example: `foo=bar,env=stage` will annotate the scanner pods with the annotations `foo: bar` and `env: stage` |
+| `scanJob.templateLabel`                       | N/A                                   | One-line comma-separated representation of the template labels which the user wants the scanner pods to be labeled with. Example: `foo=bar,env=stage` will labeled the scanner pods with the labels `foo: bar` and `env: stage` |
+| `kube-bench.imageRef`                         | `docker.io/aquasec/kube-bench:v0.6.5`  | kube-bench image reference |
+| `kube-hunter.imageRef`                        | `docker.io/aquasec/kube-hunter:0.6.3` | kube-hunter image reference |
+| `kube-hunter.quick`                           | `"false"`                             | Whether to use kube-hunter's "quick" scanning mode (subnet 24). Set to `"true"` to enable. |
 
 !!! tip
     You can find it handy to delete a configuration key, which was not created by default by the `starboard init`

--- a/pkg/operator/controller/limit_checker_test.go
+++ b/pkg/operator/controller/limit_checker_test.go
@@ -20,6 +20,7 @@ var _ = Describe("LimitChecker", func() {
 		Namespace:               "starboard-operator",
 		ConcurrentScanJobsLimit: 2,
 	}
+	defaultStarboardConfig := starboard.GetDefaultConfig()
 
 	Context("When there are more jobs than limit", func() {
 
@@ -53,7 +54,7 @@ var _ = Describe("LimitChecker", func() {
 				}},
 			).Build()
 
-			instance := controller.NewLimitChecker(config, client)
+			instance := controller.NewLimitChecker(config, client, defaultStarboardConfig)
 			limitExceeded, jobsCount, err := instance.Check(context.TODO())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(limitExceeded).To(BeTrue())
@@ -79,7 +80,7 @@ var _ = Describe("LimitChecker", func() {
 				}},
 			).Build()
 
-			instance := controller.NewLimitChecker(config, client)
+			instance := controller.NewLimitChecker(config, client, defaultStarboardConfig)
 			limitExceeded, jobsCount, err := instance.Check(context.TODO())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(limitExceeded).To(BeFalse())
@@ -87,4 +88,46 @@ var _ = Describe("LimitChecker", func() {
 		})
 
 	})
+
+	Context("When there are more jobs than limit running in different namespace", func() {
+
+		It("Should return true", func() {
+			client := fake.NewClientBuilder().WithScheme(starboard.NewScheme()).WithObjects(
+				&batchv1.Job{ObjectMeta: metav1.ObjectMeta{
+					Name:      "logs-exporter",
+					Namespace: "starboard-operator",
+				}},
+				&batchv1.Job{ObjectMeta: metav1.ObjectMeta{
+					Name:      "scan-vulnerabilityreport-hash1",
+					Namespace: "default",
+					Labels: map[string]string{
+						starboard.LabelK8SAppManagedBy: starboard.AppStarboard,
+					},
+				}},
+				&batchv1.Job{ObjectMeta: metav1.ObjectMeta{
+					Name:      "scan-vulnerabilityreport-hash2",
+					Namespace: "prod",
+					Labels: map[string]string{
+						starboard.LabelK8SAppManagedBy: starboard.AppStarboard,
+					},
+				}},
+				&batchv1.Job{ObjectMeta: metav1.ObjectMeta{
+					Name:      "scan-configauditreport-hash3",
+					Namespace: "stage",
+					Labels: map[string]string{
+						starboard.LabelK8SAppManagedBy: starboard.AppStarboard,
+					},
+				}},
+			).Build()
+			starboardConfig := defaultStarboardConfig
+			starboardConfig[starboard.KeyVulnerabilityScansInSameNamespace] = "true"
+			instance := controller.NewLimitChecker(config, client, starboardConfig)
+			limitExceeded, jobsCount, err := instance.Check(context.TODO())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(limitExceeded).To(BeTrue())
+			Expect(jobsCount).To(Equal(3))
+		})
+
+	})
+
 })

--- a/pkg/operator/controller/vulnerabilityreport.go
+++ b/pkg/operator/controller/vulnerabilityreport.go
@@ -23,6 +23,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -73,13 +74,13 @@ func (r *VulnerabilityReportReconciler) SetupWithManager(mgr ctrl.Manager) error
 			return err
 		}
 	}
+	var predicates []predicate.Predicate
+	if !r.ConfigData.VulnerabilityScanJobsInSameNamespace() {
+		predicates = append(predicates, InNamespace(r.Config.Namespace))
+	}
+	predicates = append(predicates, ManagedByStarboardOperator, IsVulnerabilityReportScan, JobHasAnyCondition)
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&batchv1.Job{}, builder.WithPredicates(
-			InNamespace(r.Config.Namespace),
-			ManagedByStarboardOperator,
-			IsVulnerabilityReportScan,
-			JobHasAnyCondition,
-		)).
+		For(&batchv1.Job{}, builder.WithPredicates(predicates...)).
 		Complete(r.reconcileJobs())
 }
 
@@ -260,7 +261,6 @@ func (r *VulnerabilityReportReconciler) submitScanJob(ctx context.Context, owner
 	}
 
 	for _, secret := range secrets {
-		secret.Namespace = r.PluginContext.GetNamespace()
 		err = r.Client.Create(ctx, secret)
 		if err != nil {
 			if k8sapierror.IsAlreadyExists(err) {

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -124,7 +124,7 @@ func Start(ctx context.Context, buildInfo starboard.BuildInfo, operatorConfig et
 	}
 
 	objectResolver := kube.ObjectResolver{Client: mgr.GetClient()}
-	limitChecker := controller.NewLimitChecker(operatorConfig, mgr.GetClient())
+	limitChecker := controller.NewLimitChecker(operatorConfig, mgr.GetClient(), starboardConfig)
 	logsReader := kube.NewLogsReader(kubeClientset)
 	secretsReader := kube.NewSecretsReader(mgr.GetClient())
 

--- a/pkg/plugin/factory.go
+++ b/pkg/plugin/factory.go
@@ -75,6 +75,7 @@ func (r *Resolver) GetVulnerabilityPlugin() (vulnerabilityreport.Plugin, starboa
 		WithNamespace(r.namespace).
 		WithServiceAccountName(r.serviceAccountName).
 		WithClient(r.client).
+		WithStarboardConfig(r.config).
 		Get()
 
 	switch scanner {

--- a/pkg/starboard/config.go
+++ b/pkg/starboard/config.go
@@ -46,14 +46,15 @@ type BuildInfo struct {
 type Scanner string
 
 const (
-	keyVulnerabilityReportsScanner = "vulnerabilityReports.scanner"
-	keyConfigAuditReportsScanner   = "configAuditReports.scanner"
-	keyKubeBenchImageRef           = "kube-bench.imageRef"
-	keyKubeHunterImageRef          = "kube-hunter.imageRef"
-	keyKubeHunterQuick             = "kube-hunter.quick"
-	keyScanJobTolerations          = "scanJob.tolerations"
-	keyScanJobAnnotations          = "scanJob.annotations"
-	keyScanJobPodTemplateLabels    = "scanJob.podTemplateLabels"
+	keyVulnerabilityReportsScanner       = "vulnerabilityReports.scanner"
+	KeyVulnerabilityScansInSameNamespace = "vulnerabilityReports.scanJobsInSameNamespace"
+	keyConfigAuditReportsScanner         = "configAuditReports.scanner"
+	keyKubeBenchImageRef                 = "kube-bench.imageRef"
+	keyKubeHunterImageRef                = "kube-hunter.imageRef"
+	keyKubeHunterQuick                   = "kube-hunter.quick"
+	keyScanJobTolerations                = "scanJob.tolerations"
+	keyScanJobAnnotations                = "scanJob.annotations"
+	keyScanJobPodTemplateLabels          = "scanJob.podTemplateLabels"
 )
 
 // ConfigData holds Starboard configuration settings as a set of key-value
@@ -86,6 +87,15 @@ func (c ConfigData) GetVulnerabilityReportsScanner() (Scanner, error) {
 		return "", fmt.Errorf("property %s not set", keyVulnerabilityReportsScanner)
 	}
 	return Scanner(value), nil
+}
+
+func (c ConfigData) VulnerabilityScanJobsInSameNamespace() bool {
+	var ok bool
+	var value string
+	if value, ok = c[KeyVulnerabilityScansInSameNamespace]; !ok {
+		return false
+	}
+	return value == "true"
 }
 
 func (c ConfigData) GetConfigAuditReportsScanner() (Scanner, error) {

--- a/pkg/starboard/plugin.go
+++ b/pkg/starboard/plugin.go
@@ -44,6 +44,8 @@ type PluginContext interface {
 	// GetServiceAccountName return the name of the K8s Service Account used to run workloads
 	// created by Starboard.
 	GetServiceAccountName() string
+	// GetStarboardConfig returns starboard configuration.
+	GetStarboardConfig() ConfigData
 }
 
 // GetPluginConfigMapName returns the name of a ConfigMap used to configure a plugin
@@ -58,6 +60,7 @@ type pluginContext struct {
 	client             client.Client
 	namespace          string
 	serviceAccountName string
+	starboardConfig    ConfigData
 }
 
 func (p *pluginContext) GetName() string {
@@ -121,6 +124,10 @@ func (p *pluginContext) GetServiceAccountName() string {
 	return p.serviceAccountName
 }
 
+func (p *pluginContext) GetStarboardConfig() ConfigData {
+	return p.starboardConfig
+}
+
 type PluginContextBuilder struct {
 	ctx *pluginContext
 }
@@ -148,6 +155,11 @@ func (b *PluginContextBuilder) WithNamespace(namespace string) *PluginContextBui
 
 func (b *PluginContextBuilder) WithServiceAccountName(name string) *PluginContextBuilder {
 	b.ctx.serviceAccountName = name
+	return b
+}
+
+func (b *PluginContextBuilder) WithStarboardConfig(config ConfigData) *PluginContextBuilder {
+	b.ctx.starboardConfig = config
 	return b
 }
 

--- a/pkg/vulnerabilityreport/builder.go
+++ b/pkg/vulnerabilityreport/builder.go
@@ -129,6 +129,11 @@ func (s *ScanJobBuilder) Get() (*batchv1.Job, []*corev1.Secret, error) {
 			},
 		},
 	}
+	// secrets will be created with scan jobs in same namespace where scan job will run
+	for i, _ := range secrets {
+		secrets[i].Namespace = s.pluginContext.GetNamespace()
+	}
+	s.updateScanJobForWorkloadNamespace(job, spec, secrets)
 
 	err = kube.ObjectToObjectMeta(s.object, &job.ObjectMeta)
 	if err != nil {
@@ -141,6 +146,23 @@ func (s *ScanJobBuilder) Get() (*batchv1.Job, []*corev1.Secret, error) {
 	}
 
 	return job, secrets, nil
+}
+
+// When run scan job in workload namespace is enabled then this method will update scanjob spec with these changes
+// - namespace same as workload
+// - service account same as workload service account
+// - ImagePullSecret same as workload imagePullSecret
+func (s *ScanJobBuilder) updateScanJobForWorkloadNamespace(job *batchv1.Job, podspec corev1.PodSpec, secrets []*corev1.Secret) {
+	operatorConfig := s.pluginContext.GetStarboardConfig()
+	if !operatorConfig.VulnerabilityScanJobsInSameNamespace() {
+		return
+	}
+	job.Namespace = s.object.GetNamespace()
+	job.Spec.Template.Spec.ServiceAccountName = podspec.ServiceAccountName
+	job.Spec.Template.Spec.ImagePullSecrets = podspec.ImagePullSecrets
+	for i, _ := range secrets {
+		secrets[i].Namespace = s.object.GetNamespace()
+	}
 }
 
 func GetScanJobName(obj client.Object) string {

--- a/pkg/vulnerabilityreport/builder_test.go
+++ b/pkg/vulnerabilityreport/builder_test.go
@@ -64,76 +64,154 @@ func TestReportBuilder(t *testing.T) {
 }
 
 func TestScanJobBuilder(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
-	job, _, err := vulnerabilityreport.NewScanJobBuilder().
-		WithPlugin(&testPlugin{}).
-		WithPluginContext(starboard.NewPluginContext().
-			WithName("test-plugin").
-			WithNamespace("starboard-ns").
-			WithServiceAccountName("starboard-sa").
-			Get()).
-		WithTimeout(3 * time.Second).
-		WithObject(&appsv1.ReplicaSet{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       "ReplicaSet",
-				APIVersion: "apps/v1",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "nginx-6799fc88d8",
-				Namespace: "prod-ns",
-			},
-			Spec: appsv1.ReplicaSetSpec{
-				Template: corev1.PodTemplateSpec{
-					Spec: corev1.PodSpec{
-						Containers: []corev1.Container{
-							{
-								Name:  "nginx",
-								Image: "nginx:1.16",
+	t.Run("Should get scan job with labels", func(t *testing.T) {
+		g := gomega.NewGomegaWithT(t)
+		job, _, err := vulnerabilityreport.NewScanJobBuilder().
+			WithPlugin(&testPlugin{}).
+			WithPluginContext(starboard.NewPluginContext().
+				WithName("test-plugin").
+				WithNamespace("starboard-ns").
+				WithServiceAccountName("starboard-sa").
+				Get()).
+			WithTimeout(3 * time.Second).
+			WithObject(&appsv1.ReplicaSet{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "ReplicaSet",
+					APIVersion: "apps/v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "nginx-6799fc88d8",
+					Namespace: "prod-ns",
+				},
+				Spec: appsv1.ReplicaSetSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:  "nginx",
+									Image: "nginx:1.16",
+								},
 							},
 						},
 					},
+					Selector: &metav1.LabelSelector{},
 				},
-				Selector: &metav1.LabelSelector{},
+			}).
+			Get()
+		g.Expect(err).ToNot(gomega.HaveOccurred())
+		g.Expect(job).ToNot(gomega.BeNil())
+		g.Expect(job).To(gomega.Equal(&batchv1.Job{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "scan-vulnerabilityreport-64d65c457",
+				Namespace: "starboard-ns",
+				Labels: map[string]string{
+					starboard.LabelK8SAppManagedBy:            "starboard",
+					starboard.LabelVulnerabilityReportScanner: "test-plugin",
+					starboard.LabelResourceKind:               "ReplicaSet",
+					starboard.LabelResourceName:               "nginx-6799fc88d8",
+					starboard.LabelResourceNamespace:          "prod-ns",
+					starboard.LabelResourceSpecHash:           "7d6c657bf7",
+				},
+				Annotations: map[string]string{
+					starboard.AnnotationContainerImages: `{"nginx":"nginx:1.16"}`,
+				},
 			},
-		}).
-		Get()
-	g.Expect(err).ToNot(gomega.HaveOccurred())
-	g.Expect(job).ToNot(gomega.BeNil())
-	g.Expect(job).To(gomega.Equal(&batchv1.Job{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "scan-vulnerabilityreport-64d65c457",
-			Namespace: "starboard-ns",
-			Labels: map[string]string{
-				starboard.LabelK8SAppManagedBy:            "starboard",
-				starboard.LabelVulnerabilityReportScanner: "test-plugin",
-				starboard.LabelResourceKind:               "ReplicaSet",
-				starboard.LabelResourceName:               "nginx-6799fc88d8",
-				starboard.LabelResourceNamespace:          "prod-ns",
-				starboard.LabelResourceSpecHash:           "7d6c657bf7",
-			},
-			Annotations: map[string]string{
-				starboard.AnnotationContainerImages: `{"nginx":"nginx:1.16"}`,
-			},
-		},
-		Spec: batchv1.JobSpec{
-			BackoffLimit:          pointer.Int32Ptr(0),
-			Completions:           pointer.Int32Ptr(1),
-			ActiveDeadlineSeconds: pointer.Int64Ptr(3),
-			Template: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						starboard.LabelK8SAppManagedBy:            "starboard",
-						starboard.LabelVulnerabilityReportScanner: "test-plugin",
-						starboard.LabelResourceKind:               "ReplicaSet",
-						starboard.LabelResourceName:               "nginx-6799fc88d8",
-						starboard.LabelResourceNamespace:          "prod-ns",
-						starboard.LabelResourceSpecHash:           "7d6c657bf7",
+			Spec: batchv1.JobSpec{
+				BackoffLimit:          pointer.Int32Ptr(0),
+				Completions:           pointer.Int32Ptr(1),
+				ActiveDeadlineSeconds: pointer.Int64Ptr(3),
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							starboard.LabelK8SAppManagedBy:            "starboard",
+							starboard.LabelVulnerabilityReportScanner: "test-plugin",
+							starboard.LabelResourceKind:               "ReplicaSet",
+							starboard.LabelResourceName:               "nginx-6799fc88d8",
+							starboard.LabelResourceNamespace:          "prod-ns",
+							starboard.LabelResourceSpecHash:           "7d6c657bf7",
+						},
 					},
+					Spec: corev1.PodSpec{},
 				},
-				Spec: corev1.PodSpec{},
 			},
-		},
-	}))
+		}))
+	})
+
+	t.Run("Should get scan job running in workload namespace", func(t *testing.T) {
+		g := gomega.NewGomegaWithT(t)
+		job, _, err := vulnerabilityreport.NewScanJobBuilder().
+			WithPlugin(&testPlugin{}).
+			WithPluginContext(starboard.NewPluginContext().
+				WithName("test-plugin").
+				WithNamespace("starboard-ns").
+				WithServiceAccountName("starboard-sa").
+				WithStarboardConfig(starboard.ConfigData{
+					starboard.KeyVulnerabilityScansInSameNamespace: "true"},
+				).
+				Get()).
+			WithTimeout(3 * time.Second).
+			WithObject(&appsv1.ReplicaSet{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "ReplicaSet",
+					APIVersion: "apps/v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "nginx-6799fc88d8",
+					Namespace: "prod-ns",
+				},
+				Spec: appsv1.ReplicaSetSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:  "nginx",
+									Image: "nginx:1.16",
+								},
+							},
+						},
+					},
+					Selector: &metav1.LabelSelector{},
+				},
+			}).
+			Get()
+		g.Expect(err).ToNot(gomega.HaveOccurred())
+		g.Expect(job).ToNot(gomega.BeNil())
+		g.Expect(job).To(gomega.Equal(&batchv1.Job{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "scan-vulnerabilityreport-64d65c457",
+				Namespace: "prod-ns",
+				Labels: map[string]string{
+					starboard.LabelK8SAppManagedBy:            "starboard",
+					starboard.LabelVulnerabilityReportScanner: "test-plugin",
+					starboard.LabelResourceKind:               "ReplicaSet",
+					starboard.LabelResourceName:               "nginx-6799fc88d8",
+					starboard.LabelResourceNamespace:          "prod-ns",
+					starboard.LabelResourceSpecHash:           "7d6c657bf7",
+				},
+				Annotations: map[string]string{
+					starboard.AnnotationContainerImages: `{"nginx":"nginx:1.16"}`,
+				},
+			},
+			Spec: batchv1.JobSpec{
+				BackoffLimit:          pointer.Int32Ptr(0),
+				Completions:           pointer.Int32Ptr(1),
+				ActiveDeadlineSeconds: pointer.Int64Ptr(3),
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							starboard.LabelK8SAppManagedBy:            "starboard",
+							starboard.LabelVulnerabilityReportScanner: "test-plugin",
+							starboard.LabelResourceKind:               "ReplicaSet",
+							starboard.LabelResourceName:               "nginx-6799fc88d8",
+							starboard.LabelResourceNamespace:          "prod-ns",
+							starboard.LabelResourceSpecHash:           "7d6c657bf7",
+						},
+					},
+					Spec: corev1.PodSpec{},
+				},
+			},
+		}))
+	})
 }
 
 type testPlugin struct {


### PR DESCRIPTION
new option in configmap starboard has added ie. ``vulnerabilityReports.scanJobsInSameNamespace`` to enable running
scan job in the workload namespace.
Once this option is enabled then vulnerability scan jobs will start running in same namespace of workload.
Also it will run with same serviceAccount and imagepullSecret of workload.
This option helps us to schedule scan job with Trivy fs command on any node.

this implements the approach mentioned here: https://github.com/aquasecurity/starboard/pull/917