### PR TITLE
fix: ignore parsing logs of deleted scan jobs

### DIFF
--- a/pkg/kube/logs.go
+++ b/pkg/kube/logs.go
@@ -29,7 +29,7 @@ func NewLogsReader(clientset kubernetes.Interface) LogsReader {
 func (r *logsReader) GetLogsByJobAndContainerName(ctx context.Context, job *batchv1.Job, containerName string) (io.ReadCloser, error) {
 	pod, err := r.getPodByJob(ctx, job)
 	if err != nil {
-		return nil, fmt.Errorf("getting pod controlled by job: %q: %w", job.Namespace+"/"+job.Name, err)
+		return nil, err
 	}
 	if pod == nil {
 		return nil, fmt.Errorf("getting pod controlled by job: %q: pod not found", job.Namespace+"/"+job.Name)

--- a/pkg/operator/controller/configauditreport.go
+++ b/pkg/operator/controller/configauditreport.go
@@ -414,7 +414,7 @@ func (r *ConfigAuditReportReconciler) processCompleteScanJob(ctx context.Context
 			log.V(1).Info("Deleting complete scan job", "owner", owner)
 			return r.deleteJob(ctx, job)
 		}
-		return fmt.Errorf("getting pod controlled by job: %q: %w", job.Namespace+"/"+job.Name, err)
+		return fmt.Errorf("getting logs for pod %q: %w", job.Namespace+"/"+job.Name, err)
 	}
 
 	reportData, err := r.Plugin.ParseConfigAuditReportData(r.PluginContext, logsStream)


### PR DESCRIPTION
fixes #873 based on @py-go suggestion

Avoid retry parse deleted scan jobs handling the `IsNotFound` error and deleting the job.
