### PR TITLE
Fix: Deletes scan jobs if their pods have been deleted and logs can't be c…

### DIFF
--- a/itest/starboard-operator/suite_test.go
+++ b/itest/starboard-operator/suite_test.go
@@ -66,9 +66,8 @@ var _ = BeforeSuite(func() {
 		AssertTimeout:         3 * time.Minute,
 		PrimaryNamespace:      corev1.NamespaceDefault,
 		PrimaryWorkloadPrefix: "wordpress",
-
-		Client: kubeClient,
-		Helper: helper.NewHelper(kubeClient),
+		Client:                kubeClient,
+		Helper:                helper.NewHelper(kubeClient),
 	}
 
 	startCtx, stopFunc = context.WithCancel(context.Background())

--- a/pkg/operator/controller/ciskubebenchreport.go
+++ b/pkg/operator/controller/ciskubebenchreport.go
@@ -280,6 +280,10 @@ func (r *CISKubeBenchReportReconciler) processCompleteScanJob(ctx context.Contex
 
 	logsStream, err := r.LogsReader.GetLogsByJobAndContainerName(ctx, job, r.Plugin.GetContainerName())
 	if err != nil {
+		if errors.IsNotFound(err) {
+			log.V(1).Info("Cached job must have been deleted")
+			return nil
+		}
 		if kube.IsPodControlledByJobNotFound(err) {
 			log.V(1).Info("Pod must have been deleted")
 			return r.deleteJob(ctx, job)
@@ -325,6 +329,10 @@ func (r *CISKubeBenchReportReconciler) processFailedScanJob(ctx context.Context,
 
 	statuses, err := r.LogsReader.GetTerminatedContainersStatusesByJob(ctx, job)
 	if err != nil {
+		if errors.IsNotFound(err) {
+			log.V(1).Info("Cached job must have been deleted")
+			return nil
+		}
 		if kube.IsPodControlledByJobNotFound(err) {
 			log.V(1).Info("Pod must have been deleted")
 			return r.deleteJob(ctx, job)

--- a/pkg/operator/controller/configauditreport.go
+++ b/pkg/operator/controller/configauditreport.go
@@ -409,6 +409,10 @@ func (r *ConfigAuditReportReconciler) processCompleteScanJob(ctx context.Context
 
 	logsStream, err := r.LogsReader.GetLogsByJobAndContainerName(ctx, job, r.Plugin.GetContainerName())
 	if err != nil {
+		if errors.IsNotFound(err) {
+			log.V(1).Info("Cached job must have been deleted")
+			return nil
+		}
 		if kube.IsPodControlledByJobNotFound(err) {
 			log.V(1).Info("Pod must have been deleted")
 			return r.deleteJob(ctx, job)
@@ -443,6 +447,10 @@ func (r *ConfigAuditReportReconciler) processFailedScanJob(ctx context.Context, 
 
 	statuses, err := r.LogsReader.GetTerminatedContainersStatusesByJob(ctx, scanJob)
 	if err != nil {
+		if errors.IsNotFound(err) {
+			log.V(1).Info("Cached job must have been deleted")
+			return nil
+		}
 		if kube.IsPodControlledByJobNotFound(err) {
 			log.V(1).Info("Pod must have been deleted")
 			return r.deleteJob(ctx, scanJob)

--- a/pkg/operator/controller/vulnerabilityreport.go
+++ b/pkg/operator/controller/vulnerabilityreport.go
@@ -370,6 +370,10 @@ func (r *VulnerabilityReportReconciler) processCompleteScanJob(ctx context.Conte
 	for containerName, containerImage := range containerImages {
 		logsStream, err := r.LogsReader.GetLogsByJobAndContainerName(ctx, job, containerName)
 		if err != nil {
+			if k8sapierror.IsNotFound(err) {
+				log.V(1).Info("Cached job must have been deleted")
+				return nil
+			}
 			if kube.IsPodControlledByJobNotFound(err) {
 				log.V(1).Info("Pod must have been deleted")
 				return r.deleteJob(ctx, job)
@@ -415,6 +419,10 @@ func (r *VulnerabilityReportReconciler) processFailedScanJob(ctx context.Context
 
 	statuses, err := r.GetTerminatedContainersStatusesByJob(ctx, scanJob)
 	if err != nil {
+		if k8sapierror.IsNotFound(err) {
+			log.V(1).Info("Cached job must have been deleted")
+			return nil
+		}
 		if kube.IsPodControlledByJobNotFound(err) {
 			log.V(1).Info("Pod must have been deleted")
 			return r.deleteJob(ctx, scanJob)

--- a/pkg/operator/controller/vulnerabilityreport.go
+++ b/pkg/operator/controller/vulnerabilityreport.go
@@ -370,6 +370,10 @@ func (r *VulnerabilityReportReconciler) processCompleteScanJob(ctx context.Conte
 	for containerName, containerImage := range containerImages {
 		logsStream, err := r.LogsReader.GetLogsByJobAndContainerName(ctx, job, containerName)
 		if err != nil {
+			if kube.IsPodControlledByJobNotFound(err) {
+				log.V(1).Info("Pod must have been deleted")
+				return r.deleteJob(ctx, job)
+			}
 			return fmt.Errorf("getting logs for pod %q: %w", job.Namespace+"/"+job.Name, err)
 		}
 		reportData, err := r.Plugin.ParseVulnerabilityReportData(r.PluginContext, containerImage, logsStream)
@@ -411,6 +415,10 @@ func (r *VulnerabilityReportReconciler) processFailedScanJob(ctx context.Context
 
 	statuses, err := r.GetTerminatedContainersStatusesByJob(ctx, scanJob)
 	if err != nil {
+		if kube.IsPodControlledByJobNotFound(err) {
+			log.V(1).Info("Pod must have been deleted")
+			return r.deleteJob(ctx, scanJob)
+		}
 		return err
 	}
 	for container, status := range statuses {


### PR DESCRIPTION
Fixes #873 and for other scan types which are not mentioned in this issue

The problem which is fixed in this PR is the following:

When a scan job creates the pod which handles scans, if this pod has been deleted before starboard parses the pod's logs, these jobs are never deleted which means when the max concurrent job setting is hit, part of this threshold is eaten up by jobs which never get deleted.

Signed-off-by: Joel Whittaker-Smith <jdws.dev@gmail.com>