### PR TITLE
chore: bump batchv1beta1 to batchv1

### DIFF
--- a/itest/starboard-operator/behavior/behavior.go
+++ b/itest/starboard-operator/behavior/behavior.go
@@ -11,7 +11,6 @@ import (
 	"github.com/aquasecurity/starboard/pkg/plugin/conftest"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
-	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -149,18 +148,18 @@ func VulnerabilityScannerBehavior(inputs *Inputs) func() {
 		Context("When CronJob is created", func() {
 
 			var ctx context.Context
-			var cronJob *batchv1beta1.CronJob
+			var cronJob *batchv1.CronJob
 
 			BeforeEach(func() {
 				ctx = context.Background()
-				cronJob = &batchv1beta1.CronJob{
+				cronJob = &batchv1.CronJob{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: inputs.PrimaryNamespace,
 						Name:      "hello-" + rand.String(5),
 					},
-					Spec: batchv1beta1.CronJobSpec{
+					Spec: batchv1.CronJobSpec{
 						Schedule: "*/1 * * * *",
-						JobTemplate: batchv1beta1.JobTemplateSpec{
+						JobTemplate: batchv1.JobTemplateSpec{
 							Spec: batchv1.JobSpec{
 								Template: corev1.PodTemplateSpec{
 									Spec: corev1.PodSpec{
@@ -325,18 +324,18 @@ func ConfigurationCheckerBehavior(inputs *Inputs) func() {
 		Context("When CronJob is created", func() {
 
 			var ctx context.Context
-			var cronJob *batchv1beta1.CronJob
+			var cronJob *batchv1.CronJob
 
 			BeforeEach(func() {
 				ctx = context.Background()
-				cronJob = &batchv1beta1.CronJob{
+				cronJob = &batchv1.CronJob{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: inputs.PrimaryNamespace,
 						Name:      "hello-" + rand.String(5),
 					},
-					Spec: batchv1beta1.CronJobSpec{
+					Spec: batchv1.CronJobSpec{
 						Schedule: "*/1 * * * *",
-						JobTemplate: batchv1beta1.JobTemplateSpec{
+						JobTemplate: batchv1.JobTemplateSpec{
 							Spec: batchv1.JobSpec{
 								Template: corev1.PodTemplateSpec{
 									Spec: corev1.PodSpec{

--- a/itest/starboard/starboard_cli_test.go
+++ b/itest/starboard/starboard_cli_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/aquasecurity/starboard/pkg/vulnerabilityreport"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
-	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -1147,14 +1146,14 @@ var _ = Describe("Starboard CLI", func() {
 			var ctx context.Context
 			BeforeEach(func() {
 				ctx = context.TODO()
-				object = &batchv1beta1.CronJob{
+				object = &batchv1.CronJob{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "hello" + "-" + rand.String(5),
 						Namespace: testNamespace.Name,
 					},
-					Spec: batchv1beta1.CronJobSpec{
+					Spec: batchv1.CronJobSpec{
 						Schedule: "*/1 * * * *",
-						JobTemplate: batchv1beta1.JobTemplateSpec{
+						JobTemplate: batchv1.JobTemplateSpec{
 							Spec: batchv1.JobSpec{
 								Template: corev1.PodTemplateSpec{
 									Spec: corev1.PodSpec{

--- a/pkg/kube/object_test.go
+++ b/pkg/kube/object_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
-	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -409,9 +408,9 @@ func TestGetPodSpec(t *testing.T) {
 		},
 		{
 			name: "Should return PodSpec for CronJob",
-			object: &batchv1beta1.CronJob{
-				Spec: batchv1beta1.CronJobSpec{
-					JobTemplate: batchv1beta1.JobTemplateSpec{
+			object: &batchv1.CronJob{
+				Spec: batchv1.CronJobSpec{
+					JobTemplate: batchv1.JobTemplateSpec{
 						Spec: batchv1.JobSpec{
 							Template: corev1.PodTemplateSpec{
 								Spec: corev1.PodSpec{

--- a/pkg/operator/controller/configauditreport.go
+++ b/pkg/operator/controller/configauditreport.go
@@ -14,7 +14,6 @@ import (
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
-	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -56,7 +55,7 @@ func (r *ConfigAuditReportReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		{kind: kube.KindReplicationController, forObject: &corev1.ReplicationController{}, ownsObject: &v1alpha1.ConfigAuditReport{}},
 		{kind: kube.KindStatefulSet, forObject: &appsv1.StatefulSet{}, ownsObject: &v1alpha1.ConfigAuditReport{}},
 		{kind: kube.KindDaemonSet, forObject: &appsv1.DaemonSet{}, ownsObject: &v1alpha1.ConfigAuditReport{}},
-		{kind: kube.KindCronJob, forObject: &batchv1beta1.CronJob{}, ownsObject: &v1alpha1.ConfigAuditReport{}},
+		{kind: kube.KindCronJob, forObject: &batchv1.CronJob{}, ownsObject: &v1alpha1.ConfigAuditReport{}},
 		{kind: kube.KindJob, forObject: &batchv1.Job{}, ownsObject: &v1alpha1.ConfigAuditReport{}},
 		{kind: kube.KindService, forObject: &corev1.Service{}, ownsObject: &v1alpha1.ConfigAuditReport{}},
 		{kind: kube.KindConfigMap, forObject: &corev1.ConfigMap{}, ownsObject: &v1alpha1.ConfigAuditReport{}},

--- a/pkg/operator/controller/vulnerabilityreport.go
+++ b/pkg/operator/controller/vulnerabilityreport.go
@@ -16,7 +16,6 @@ import (
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
-	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	k8sapierror "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -57,7 +56,7 @@ func (r *VulnerabilityReportReconciler) SetupWithManager(mgr ctrl.Manager) error
 		{kind: kube.KindReplicationController, forObject: &corev1.ReplicationController{}, ownsObject: &v1alpha1.VulnerabilityReport{}},
 		{kind: kube.KindStatefulSet, forObject: &appsv1.StatefulSet{}, ownsObject: &v1alpha1.VulnerabilityReport{}},
 		{kind: kube.KindDaemonSet, forObject: &appsv1.DaemonSet{}, ownsObject: &v1alpha1.VulnerabilityReport{}},
-		{kind: kube.KindCronJob, forObject: &batchv1beta1.CronJob{}, ownsObject: &v1alpha1.VulnerabilityReport{}},
+		{kind: kube.KindCronJob, forObject: &batchv1.CronJob{}, ownsObject: &v1alpha1.VulnerabilityReport{}},
 		{kind: kube.KindJob, forObject: &batchv1.Job{}, ownsObject: &v1alpha1.VulnerabilityReport{}},
 	}
 

--- a/pkg/starboard/config.go
+++ b/pkg/starboard/config.go
@@ -10,7 +10,6 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
-	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	coordinationv1 "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -27,7 +26,6 @@ func NewScheme() *runtime.Scheme {
 	_ = corev1.AddToScheme(scheme)
 	_ = appsv1.AddToScheme(scheme)
 	_ = batchv1.AddToScheme(scheme)
-	_ = batchv1beta1.AddToScheme(scheme)
 	_ = rbacv1.AddToScheme(scheme)
 	_ = v1alpha1.AddToScheme(scheme)
 	_ = coordinationv1.AddToScheme(scheme)


### PR DESCRIPTION
This patch is getting rid of the following warning:

batch/v1beta1 CronJob is deprecated in v1.21+, unavailable in v1.25+; use batch/v1 CronJob

Signed-off-by: Daniel Pacak <pacak.daniel@gmail.com>