### PR TITLE
feat(cli): add check command that scans and prints results in pretty format

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/gorhill/cronexpr v0.0.0-20180427100037-88b0669f7d75
 	github.com/hashicorp/go-version v1.4.0
+	github.com/olekukonko/tablewriter v0.0.5
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.18.1
 	github.com/open-policy-agent/opa v0.38.0
@@ -71,6 +72,7 @@ require (
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect
 	github.com/mailru/easyjson v0.7.6 // indirect
+	github.com/mattn/go-runewidth v0.0.9 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -676,6 +676,7 @@ github.com/mattn/go-isatty v0.0.11/go.mod h1:PhnuNfih5lzO57/f3n+odYbM4JtupLOxQOA
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
+github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-shellwords v1.0.3/go.mod h1:3xCvwCdWdlDJUrvuMn7Wuy9eWs4pE8vqg+NOMyg4B2o=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
@@ -732,6 +733,7 @@ github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
+github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/onsi/ginkgo v0.0.0-20151202141238-7f8ab55aaf3b/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=

--- a/pkg/cmd/check.go
+++ b/pkg/cmd/check.go
@@ -1,0 +1,190 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/aquasecurity/starboard/pkg/configauditreport"
+	"github.com/aquasecurity/starboard/pkg/ext"
+	"github.com/aquasecurity/starboard/pkg/kube"
+	"github.com/aquasecurity/starboard/pkg/kubebench"
+	"github.com/aquasecurity/starboard/pkg/plugin"
+	"github.com/aquasecurity/starboard/pkg/starboard"
+	"github.com/aquasecurity/starboard/pkg/vulnerabilityreport"
+	"github.com/olekukonko/tablewriter"
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func NewCheckCommand(buildInfo starboard.BuildInfo, cf *genericclioptions.ConfigFlags, out io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use: "check",
+		Aliases: []string{
+			"verify",
+			"validate",
+		},
+		Short: "Check Kubernetes resources for configuration best practices and known vulnerabilities",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+			ns, _, err := cf.ToRawKubeConfigLoader().Namespace()
+			if err != nil {
+				return err
+			}
+			mapper, err := cf.ToRESTMapper()
+			if err != nil {
+				return err
+			}
+			workload, _, err := WorkloadFromArgs(mapper, ns, args)
+			if err != nil {
+				return err
+			}
+			kubeConfig, err := cf.ToRESTConfig()
+			if err != nil {
+				return err
+			}
+			kubeClientset, err := kubernetes.NewForConfig(kubeConfig)
+			if err != nil {
+				return err
+			}
+			scheme := starboard.NewScheme()
+			kubeClient, err := client.New(kubeConfig, client.Options{Scheme: scheme})
+			opts, err := getScannerOpts(cmd)
+			if err != nil {
+				return err
+			}
+			config, err := starboard.NewConfigManager(kubeClientset, starboard.NamespaceName).Read(ctx)
+			if err != nil {
+				return err
+			}
+
+			checker := Checker{
+				BuildInfo:   buildInfo,
+				ConfigData:  config,
+				ScannerOpts: opts,
+				Scheme:      scheme,
+				Clientset:   kubeClientset,
+				Client:      kubeClient,
+			}
+
+			return checker.Check(ctx, workload, out)
+		},
+	}
+
+	registerScannerOpts(cmd)
+
+	return cmd
+}
+
+type Checker struct {
+	starboard.BuildInfo
+	starboard.ConfigData
+	kube.ScannerOpts
+	*runtime.Scheme
+	*kubernetes.Clientset
+	client.Client
+}
+
+func (c *Checker) Check(ctx context.Context, resource kube.ObjectRef, out io.Writer) error {
+	switch resource.Kind {
+	case kube.KindDeployment, kube.KindReplicaSet, kube.KindReplicationController, kube.KindPod, kube.KindStatefulSet, kube.KindDaemonSet, kube.KindJob, kube.KindCronJob:
+		return c.checkWorkload(ctx, resource, out)
+	case kube.KindNode:
+		return c.checkNode(ctx, resource, out)
+	default:
+		return fmt.Errorf("unsupproted resource kind: %s", resource.Kind)
+	}
+}
+
+func (c *Checker) checkWorkload(ctx context.Context, workload kube.ObjectRef, out io.Writer) error {
+	pluginResolver := plugin.NewResolver().
+		WithBuildInfo(c.BuildInfo).
+		WithNamespace(starboard.NamespaceName).
+		WithServiceAccountName(starboard.ServiceAccountName).
+		WithConfig(c.ConfigData).
+		WithClient(c.Client)
+
+	vulnerabilityPlugin, pluginContext, err := pluginResolver.GetVulnerabilityPlugin()
+	vulnerabilityScanner := vulnerabilityreport.NewScanner(c.Clientset, c.Client, vulnerabilityPlugin, pluginContext, c.ConfigData, c.ScannerOpts)
+	reports, err := vulnerabilityScanner.Scan(ctx, workload)
+	if err != nil {
+		return err
+	}
+
+	for _, report := range reports {
+		fmt.Fprintf(out, "%s/%s:%s\n", report.Report.Registry.Server, report.Report.Artifact.Repository, report.Report.Artifact.Tag)
+		table := tablewriter.NewWriter(out)
+		table.SetHeader([]string{"Vulnerability ID", "Severity", "Resource", "Version", "Fixed Version"})
+		for _, c := range report.Report.Vulnerabilities {
+			if c.FixedVersion == "" {
+				continue
+			}
+			table.Append([]string{c.VulnerabilityID, string(c.Severity), c.Resource, c.InstalledVersion, c.FixedVersion})
+
+		}
+		table.Render()
+	}
+
+	configAuditPlugin, pluginContext, err := pluginResolver.GetConfigAuditPlugin()
+	scanner := configauditreport.NewScanner(c.Clientset, c.Client, configAuditPlugin, pluginContext, c.ConfigData, c.ScannerOpts)
+	reportBuilder, err := scanner.Scan(ctx, workload)
+	if err != nil {
+		return err
+	}
+	readWriter := configauditreport.NewReadWriter(c.Client)
+	err = reportBuilder.Write(ctx, readWriter)
+	if err != nil {
+		return err
+	}
+	report, err := readWriter.FindReportByOwnerInHierarchy(ctx, workload)
+	if err != nil {
+		return nil
+	}
+
+	if report == nil {
+		fmt.Fprintf(out, "No reports found in %s namespace.\n", workload.Namespace)
+		return nil
+	}
+
+	table := tablewriter.NewWriter(out)
+	table.SetHeader([]string{"Check ID", "Category", "Severity", "Message"})
+
+	for _, c := range report.Report.Checks {
+		if c.Success {
+			continue
+		}
+		table.Append([]string{c.ID, c.Category, c.Severity, c.Message})
+	}
+	table.Render()
+	return nil
+}
+
+func (c *Checker) checkNode(ctx context.Context, node kube.ObjectRef, out io.Writer) error {
+	plugin := kubebench.NewKubeBenchPlugin(ext.NewSystemClock(), c.ConfigData)
+	scanner := kubebench.NewScanner(c.Scheme, c.Clientset, plugin, c.ConfigData, c.ScannerOpts)
+
+	nodes, err := GetNodes(ctx, c.Clientset, node.Name)
+	if err != nil {
+		return fmt.Errorf("getting nodes: %w", err)
+	}
+
+	report, err := scanner.Scan(ctx, nodes[0])
+
+	for _, section := range report.Report.Sections {
+		fmt.Fprintf(out, "[INFO] %s %s\n", section.ID, section.Text)
+		for _, test := range section.Tests {
+			fmt.Fprintf(out, "[INFO] %s %s\n", test.Section, test.Desc)
+			for _, result := range test.Results {
+				if result.Status == "PASS" {
+					continue
+				}
+				fmt.Fprintf(out, "[%s] %s %s\n", result.Status, result.TestNumber, result.TestDesc)
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -58,6 +58,7 @@ func NewRootCmd(buildInfo starboard.BuildInfo, args []string, outWriter io.Write
 	rootCmd.AddCommand(NewReportCmd(buildInfo, cf, outWriter))
 	rootCmd.AddCommand(NewCleanupCmd(buildInfo, cf))
 	rootCmd.AddCommand(NewConfigCmd(cf, outWriter))
+	rootCmd.AddCommand(NewCheckCommand(buildInfo, cf, outWriter))
 
 	SetGlobalFlags(cf, rootCmd)
 


### PR DESCRIPTION
### Check Kubernetes Workloads
```console
$ kubectl create deploy nginx --image nginx:1.16
```

```console
$ starboard install && starboard check deploy/nginx
index.docker.io/library/nginx:1.16
+------------------+----------+-----------------+---------------------------+---------------------------+
| VULNERABILITY ID | SEVERITY |    RESOURCE     |          VERSION          |       FIXED VERSION       |
+------------------+----------+-----------------+---------------------------+---------------------------+
| CVE-2020-27350   | MEDIUM   | apt             | 1.8.2                     | 1.8.2.2                   |
| CVE-2020-3810    | MEDIUM   | apt             | 1.8.2                     | 1.8.2.1                   |
| CVE-2020-27350   | MEDIUM   | libapt-pkg5.0   | 1.8.2                     | 1.8.2.2                   |
| CVE-2020-3810    | MEDIUM   | libapt-pkg5.0   | 1.8.2                     | 1.8.2.1                   |
| CVE-2019-20367   | CRITICAL | libbsd0         | 0.9.1-2                   | 0.9.1-2+deb10u1           |
| CVE-2022-22822   | CRITICAL | libexpat1       | 2.2.6-2+deb10u1           | 2.2.6-2+deb10u2           |
+------------------+----------+-----------------+---------------------------+---------------------------+
+----------------------------+-------------+----------+--------------------------------+
|          CHECK ID          |  CATEGORY   | SEVERITY |            MESSAGE             |
+----------------------------+-------------+----------+--------------------------------+
| insecureCapabilities       | Security    | warning  | Container should not have      |
|                            |             |          | insecure capabilities          |
| notReadOnlyRootFilesystem  | Security    | warning  | Filesystem should be read only |
| runAsRootAllowed           | Security    | warning  | Should not be allowed to run   |
|                            |             |          | as root                        |
| cpuLimitsMissing           | Efficiency  | warning  | CPU limits should be set       |
| cpuRequestsMissing         | Efficiency  | warning  | CPU requests should be set     |
| memoryRequestsMissing      | Efficiency  | warning  | Memory requests should be set  |
| readinessProbeMissing      | Reliability | warning  | Readiness probe should be      |
|                            |             |          | configured                     |
| livenessProbeMissing       | Reliability | warning  | Liveness probe should be       |
|                            |             |          | configured                     |
| memoryLimitsMissing        | Efficiency  | warning  | Memory limits should be set    |
| privilegeEscalationAllowed | Security    | danger   | Privilege escalation should    |
|                            |             |          | not be allowed                 |
+----------------------------+-------------+----------+--------------------------------+
```

### Check Kubernetes Nodes

```console
$ kubectl get nodes
NAME                 STATUS   ROLES                  AGE   VERSION
kind-control-plane   Ready    control-plane,master   23h   v1.21.1
```

```console
$ starboard install && starboard check node/kind-control-plane
[INFO] 1 Master Node Security Configuration
[INFO] 1.1 Master Node Configuration Files
[WARN] 1.1.9 Ensure that the Container Network Interface file permissions are set to 644 or more restrictive (Manual)
[WARN] 1.1.10 Ensure that the Container Network Interface file ownership is set to root:root (Manual)
[FAIL] 1.1.12 Ensure that the etcd data directory ownership is set to etcd:etcd (Automated)
[INFO] 1.2 API Server
[WARN] 1.2.1 Ensure that the --anonymous-auth argument is set to false (Manual)
[FAIL] 1.2.5 Ensure that the --kubelet-certificate-authority argument is set as appropriate (Automated)
[WARN] 1.2.9 Ensure that the admission control plugin EventRateLimit is set (Manual)
[WARN] 1.2.11 Ensure that the admission control plugin AlwaysPullImages is set (Manual)
[WARN] 1.2.12 Ensure that the admission control plugin SecurityContextDeny is set if PodSecurityPolicy is not used (Manual)
[FAIL] 1.2.15 Ensure that the admission control plugin PodSecurityPolicy is set (Automated)
[FAIL] 1.2.20 Ensure that the --profiling argument is set to false (Automated)
[FAIL] 1.2.21 Ensure that the --audit-log-path argument is set (Automated)
[FAIL] 1.2.22 Ensure that the --audit-log-maxage argument is set to 30 or as appropriate (Automated)
[FAIL] 1.2.23 Ensure that the --audit-log-maxbackup argument is set to 10 or as appropriate (Automated)
[FAIL] 1.2.24 Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate (Automated)
[WARN] 1.2.25 Ensure that the --request-timeout argument is set as appropriate (Manual)
[WARN] 1.2.32 Ensure that the --encryption-provider-config argument is set as appropriate (Manual)
[WARN] 1.2.33 Ensure that encryption providers are appropriately configured (Manual)
[WARN] 1.2.34 Ensure that the API Server only makes use of Strong Cryptographic Ciphers (Manual)
[INFO] 1.3 Controller Manager
[WARN] 1.3.1 Ensure that the --terminated-pod-gc-threshold argument is set as appropriate (Manual)
[FAIL] 1.3.2 Ensure that the --profiling argument is set to false (Automated)
[INFO] 1.4 Scheduler
[FAIL] 1.4.1 Ensure that the --profiling argument is set to false (Automated)
[INFO] 2 Etcd Node Configuration
[INFO] 2 Etcd Node Configuration Files
[INFO] 3 Control Plane Configuration
[INFO] 3.1 Authentication and Authorization
[WARN] 3.1.1 Client certificate authentication should not be used for users (Manual)
[INFO] 3.2 Logging
[WARN] 3.2.1 Ensure that a minimal audit policy is created (Manual)
[WARN] 3.2.2 Ensure that the audit policy covers key security concerns (Manual)
[INFO] 4 Worker Node Security Configuration
[INFO] 4.1 Worker Node Configuration Files
[INFO] 4.2 Kubelet
[FAIL] 4.2.6 Ensure that the --protect-kernel-defaults argument is set to true (Automated)
[WARN] 4.2.9 Ensure that the --event-qps argument is set to 0 or a level which ensures appropriate event capture (Manual)
[WARN] 4.2.10 Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Manual)
[WARN] 4.2.13 Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers (Manual)
[INFO] 5 Kubernetes Policies
[INFO] 5.1 RBAC and Service Accounts
[WARN] 5.1.1 Ensure that the cluster-admin role is only used where required (Manual)
[WARN] 5.1.2 Minimize access to secrets (Manual)
[WARN] 5.1.3 Minimize wildcard use in Roles and ClusterRoles (Manual)
[WARN] 5.1.4 Minimize access to create pods (Manual)
[WARN] 5.1.5 Ensure that default service accounts are not actively used. (Manual)
[WARN] 5.1.6 Ensure that Service Account Tokens are only mounted where necessary (Manual)
[WARN] 5.1.7 Avoid use of system:masters group (Manual)
[WARN] 5.1.8 Limit use of the Bind, Impersonate and Escalate permissions in the Kubernetes cluster (Manual)
[INFO] 5.2 Pod Security Policies
[WARN] 5.2.1 Minimize the admission of privileged containers (Automated)
[WARN] 5.2.2 Minimize the admission of containers wishing to share the host process ID namespace (Automated)
[WARN] 5.2.3 Minimize the admission of containers wishing to share the host IPC namespace (Automated)
[WARN] 5.2.4 Minimize the admission of containers wishing to share the host network namespace (Automated)
[WARN] 5.2.5 Minimize the admission of containers with allowPrivilegeEscalation (Automated)
[WARN] 5.2.6 Minimize the admission of root containers (Automated)
[WARN] 5.2.7 Minimize the admission of containers with the NET_RAW capability (Automated)
[WARN] 5.2.8 Minimize the admission of containers with added capabilities (Automated)
[WARN] 5.2.9 Minimize the admission of containers with capabilities assigned (Manual)
[INFO] 5.3 Network Policies and CNI
[WARN] 5.3.1 Ensure that the CNI in use supports Network Policies (Manual)
[WARN] 5.3.2 Ensure that all Namespaces have Network Policies defined (Manual)
[INFO] 5.4 Secrets Management
[WARN] 5.4.1 Prefer using secrets as files over secrets as environment variables (Manual)
[WARN] 5.4.2 Consider external secret storage (Manual)
[INFO] 5.5 Extensible Admission Control
[WARN] 5.5.1 Configure Image Provenance using ImagePolicyWebhook admission controller (Manual)
[INFO] 5.7 General Policies
[WARN] 5.7.1 Create administrative boundaries between resources using namespaces (Manual)
[WARN] 5.7.2 Ensure that the seccomp profile is set to docker/default in your pod definitions (Manual)
[WARN] 5.7.3 Apply Security Context to Your Pods and Containers (Manual)
[WARN] 5.7.4 The default namespace should not be used (Manual)
```

Signed-off-by: Daniel Pacak <pacak.daniel@gmail.com>