### PR TITLE
feat(starboard-scanner-aqua): Add support for fs scan option

### DIFF
--- a/pkg/plugin/aqua/client/client_integration_test.go
+++ b/pkg/plugin/aqua/client/client_integration_test.go
@@ -12,7 +12,7 @@ func TestClient(t *testing.T) {
 		t.Skip("Run this test manually")
 	}
 
-	c := NewClient("http://aqua.domain", Authorization{
+	c, _ := NewClient("http://aqua.domain", Authorization{
 		Basic: &UsernameAndPassword{"administrator", "Password12345"}})
 
 	t.Run("Should list registries", func(t *testing.T) {

--- a/pkg/plugin/aqua/scanner/cli/types.go
+++ b/pkg/plugin/aqua/scanner/cli/types.go
@@ -1,5 +1,7 @@
 package cli
 
+import "github.com/aquasecurity/starboard/pkg/plugin/aqua/client"
+
 type ResourceType int
 
 const (
@@ -7,6 +9,22 @@ const (
 	Library
 	Package
 )
+
+// Command to scan image or filesystem.
+type Command string
+
+const (
+	Filesystem Command = "filesystem"
+	Image      Command = "image"
+)
+
+type Options struct {
+	Version      string
+	BaseURL      string
+	Credentials  client.UsernameAndPassword
+	RegistryName string
+	Command      string
+}
 
 type ScanReport struct {
 	Image          string               `json:"image"`


### PR DESCRIPTION
1. starboard-scanner-aqua shim to support filesystem command, so that scannercli fs-scan commnad is executed.
2. refactor code to get auth-key from aqua console api url