### PR TITLE
fix(ci): use Go 1.17 in release snapshot workflow

### DIFF
--- a/.github/workflows/release-snapshot.yaml
+++ b/.github/workflows/release-snapshot.yaml
@@ -7,6 +7,9 @@ on:
   schedule:
     - cron: "0 0 * * *"  # every night
 
+env:
+  GO_VERSION: "1.17"
+
 jobs:
   release-snapshot:
     name: Release unversioned snapshot
@@ -36,7 +39,7 @@ jobs:
       - name: Release snapshot
         uses: goreleaser/goreleaser-action@v2
         with:
-          version: v1.1.0
+          version: v1.5.0
           args: release --snapshot --skip-publish --rm-dist
       - name: Scan Starboard CLI image for vulnerabilities
         uses: aquasecurity/trivy-action@master

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -198,7 +198,7 @@ jobs:
       - name: Release
         uses: goreleaser/goreleaser-action@v2
         with:
-          version: v1.1.0
+          version: v1.5.0
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Signed-off-by: Daniel Pacak <pacak.daniel@gmail.com>