### PR TITLE
chore: version bump of trivy to 0.24.2

### DIFF
--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -94,7 +94,7 @@ trivy:
   createConfig: true
 
   # imageRef the Trivy image reference.
-  imageRef: docker.io/aquasec/trivy:0.23.0
+  imageRef: docker.io/aquasec/trivy:0.24.2
 
   # mode is the Trivy client mode. Either Standalone or ClientServer. Depending
   # on the active mode other settings might be applicable or required.

--- a/deploy/static/03-starboard-operator.config.yaml
+++ b/deploy/static/03-starboard-operator.config.yaml
@@ -47,7 +47,7 @@ metadata:
     app.kubernetes.io/version: "0.14.1"
     app.kubernetes.io/managed-by: kubectl
 data:
-  trivy.imageRef: "docker.io/aquasec/trivy:0.23.0"
+  trivy.imageRef: "docker.io/aquasec/trivy:0.24.2"
   trivy.mode: "Standalone"
   trivy.severity: "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"
   trivy.timeout: "5m0s"

--- a/deploy/static/starboard.yaml
+++ b/deploy/static/starboard.yaml
@@ -628,7 +628,7 @@ metadata:
     app.kubernetes.io/version: "0.14.1"
     app.kubernetes.io/managed-by: kubectl
 data:
-  trivy.imageRef: "docker.io/aquasec/trivy:0.23.0"
+  trivy.imageRef: "docker.io/aquasec/trivy:0.24.2"
   trivy.mode: "Standalone"
   trivy.severity: "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"
   trivy.timeout: "5m0s"

--- a/docs/integrations/vulnerability-scanners/trivy.md
+++ b/docs/integrations/vulnerability-scanners/trivy.md
@@ -82,7 +82,7 @@ EOF
 
 | CONFIGMAP KEY                      | DEFAULT                            | DESCRIPTION                                                                                                                                                         |
 |------------------------------------|------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `trivy.imageRef`                   | `docker.io/aquasec/trivy:0.23.0`   | Trivy image reference                                                                                                                                               |
+| `trivy.imageRef`                   | `docker.io/aquasec/trivy:0.24.2`   | Trivy image reference                                                                                                                                               |
 | `trivy.mode`                       | `Standalone`                       | Trivy client mode. Either `Standalone` or `ClientServer`. Depending on the active mode other settings might be applicable or required.                              |
 | `trivy.severity`                   | `UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL` | A comma separated list of severity levels reported by Trivy                                                                                                         |
 | `trivy.ignoreUnfixed`              | N/A                                | Whether to show only fixed vulnerabilities in vulnerabilities reported by Trivy. Set to `"true"` to enable it.                                                      |

--- a/itest/matcher/matcher.go
+++ b/itest/matcher/matcher.go
@@ -22,7 +22,7 @@ var (
 	trivyScanner = v1alpha1.Scanner{
 		Name:    "Trivy",
 		Vendor:  "Aqua Security",
-		Version: "0.23.0",
+		Version: "0.24.2",
 	}
 	polarisScanner = v1alpha1.Scanner{
 		Name:    "Polaris",

--- a/itest/matcher/matcher_test.go
+++ b/itest/matcher/matcher_test.go
@@ -58,7 +58,7 @@ func TestVulnerabilityReportMatcher(t *testing.T) {
 				Scanner: v1alpha1.Scanner{
 					Name:    "Trivy",
 					Vendor:  "Aqua Security",
-					Version: "0.23.0",
+					Version: "0.24.2",
 				},
 				Vulnerabilities: []v1alpha1.Vulnerability{},
 			},

--- a/pkg/plugin/trivy/plugin.go
+++ b/pkg/plugin/trivy/plugin.go
@@ -234,7 +234,7 @@ func NewPlugin(clock ext.Clock, idGenerator ext.IDGenerator, client client.Clien
 func (p *plugin) Init(ctx starboard.PluginContext) error {
 	return ctx.EnsureConfig(starboard.PluginConfig{
 		Data: map[string]string{
-			keyTrivyImageRef: "docker.io/aquasec/trivy:0.23.0",
+			keyTrivyImageRef: "docker.io/aquasec/trivy:0.24.2",
 			keyTrivySeverity: "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL",
 			keyTrivyMode:     string(Standalone),
 			keyTrivyTimeout:  "5m0s",

--- a/pkg/plugin/trivy/plugin_test.go
+++ b/pkg/plugin/trivy/plugin_test.go
@@ -470,7 +470,7 @@ func TestPlugin_Init(t *testing.T) {
 				ResourceVersion: "1",
 			},
 			Data: map[string]string{
-				"trivy.imageRef": "docker.io/aquasec/trivy:0.23.0",
+				"trivy.imageRef": "docker.io/aquasec/trivy:0.24.2",
 				"trivy.severity": "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL",
 				"trivy.mode":     "Standalone",
 				"trivy.timeout":  "5m0s",
@@ -496,7 +496,7 @@ func TestPlugin_Init(t *testing.T) {
 					ResourceVersion: "1",
 				},
 				Data: map[string]string{
-					"trivy.imageRef": "docker.io/aquasec/trivy:0.23.0",
+					"trivy.imageRef": "docker.io/aquasec/trivy:0.24.2",
 					"trivy.severity": "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL",
 					"trivy.mode":     "Standalone",
 				},
@@ -530,7 +530,7 @@ func TestPlugin_Init(t *testing.T) {
 				ResourceVersion: "1",
 			},
 			Data: map[string]string{
-				"trivy.imageRef": "docker.io/aquasec/trivy:0.23.0",
+				"trivy.imageRef": "docker.io/aquasec/trivy:0.24.2",
 				"trivy.severity": "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL",
 				"trivy.mode":     "Standalone",
 			},
@@ -2655,7 +2655,7 @@ CVE-2019-1543`,
 		{
 			name: "Trivy fs scan command in Standalone mode",
 			config: map[string]string{
-				"trivy.imageRef":                  "docker.io/aquasec/trivy:0.23.0",
+				"trivy.imageRef":                  "docker.io/aquasec/trivy:0.24.2",
 				"trivy.mode":                      string(trivy.Standalone),
 				"trivy.command":                   string(trivy.Filesystem),
 				"trivy.resources.requests.cpu":    "100m",
@@ -2699,7 +2699,7 @@ CVE-2019-1543`,
 				InitContainers: []corev1.Container{
 					{
 						Name:                     "00000000-0000-0000-0000-000000000001",
-						Image:                    "docker.io/aquasec/trivy:0.23.0",
+						Image:                    "docker.io/aquasec/trivy:0.24.2",
 						ImagePullPolicy:          corev1.PullIfNotPresent,
 						TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 						Command: []string{
@@ -2728,7 +2728,7 @@ CVE-2019-1543`,
 					},
 					{
 						Name:                     "00000000-0000-0000-0000-000000000002",
-						Image:                    "docker.io/aquasec/trivy:0.23.0",
+						Image:                    "docker.io/aquasec/trivy:0.24.2",
 						ImagePullPolicy:          corev1.PullIfNotPresent,
 						TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 						Env: []corev1.EnvVar{


### PR DESCRIPTION
Signed-off-by: Engin Diri <engin.diri@mail.schwarz>

This PR fixes #1007, this is needed to ensure the #1003 is working, as we need the TRIVY_INSECURE flag.

 

