### PR TITLE
fix(helm): grant permissions to get,list,watch ciskubebenchreports

### DIFF
--- a/deploy/helm/templates/rbac.yaml
+++ b/deploy/helm/templates/rbac.yaml
@@ -14,14 +14,8 @@ metadata:
 
 {{- if .Values.rbac.create }}
 ---
-{{- /*
-Create (Cluster)Role and (Cluster)RoleBinding depending on if the Helm chart is
-installed in a namespace different from the targetNamespace.
-*/}}
-{{- $clusterWide := not (eq .Release.Namespace (tpl .Values.targetNamespaces .)) }}
-{{- $conditionalClusterPrefix := $clusterWide | ternary "Cluster" "" }}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: {{ $conditionalClusterPrefix }}Role
+kind: ClusterRole
 metadata:
   name: {{ include "starboard-operator.fullname" . }}
   labels:
@@ -168,14 +162,14 @@ rules:
   {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: {{ $conditionalClusterPrefix }}RoleBinding
+kind: ClusterRoleBinding
 metadata:
   name: {{ include "starboard-operator.fullname" . }}
   labels:
     {{- include "starboard-operator.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: {{ $conditionalClusterPrefix }}Role
+  kind: ClusterRole
   name: {{ include "starboard-operator.fullname" . }}
 subjects:
   - kind: ServiceAccount


### PR DESCRIPTION
Initially, we wanted to implement the least privileged principle
by creating Role or ClusterRole depending on install mode.
For example, we created Role if the target namespace was the same
as the operator namespace. However, this logic was too simple
because we have cluster-scoped CRDs, e.g. CISKubeBenchReport, that
require ClusterRole to grant RBAC permissions.

Resolves: #1001

Signed-off-by: Daniel Pacak <pacak.daniel@gmail.com>