### PR TITLE
fix: critial is a typo

### DIFF
--- a/deploy/crd/clusterconfigauditreports.crd.yaml
+++ b/deploy/crd/clusterconfigauditreports.crd.yaml
@@ -23,9 +23,9 @@ spec:
           description: The age of the report
         - jsonPath: .report.summary.criticalCount
           type: integer
-          name: Critial
+          name: Critical
           priority: 1
-          description: The number of failed checks with critial severity
+          description: The number of failed checks with critical severity
         - jsonPath: .report.summary.highCount
           type: integer
           name: High

--- a/deploy/crd/configauditreports.crd.yaml
+++ b/deploy/crd/configauditreports.crd.yaml
@@ -23,9 +23,9 @@ spec:
           description: The age of the report
         - jsonPath: .report.summary.criticalCount
           type: integer
-          name: Critial
+          name: Critical
           priority: 1
-          description: The number of failed checks with critial severity
+          description: The number of failed checks with critical severity
         - jsonPath: .report.summary.highCount
           type: integer
           name: High

--- a/deploy/static/starboard.yaml
+++ b/deploy/static/starboard.yaml
@@ -267,9 +267,9 @@ spec:
           description: The age of the report
         - jsonPath: .report.summary.criticalCount
           type: integer
-          name: Critial
+          name: Critical
           priority: 1
-          description: The number of failed checks with critial severity
+          description: The number of failed checks with critical severity
         - jsonPath: .report.summary.highCount
           type: integer
           name: High
@@ -324,9 +324,9 @@ spec:
           description: The age of the report
         - jsonPath: .report.summary.criticalCount
           type: integer
-          name: Critial
+          name: Critical
           priority: 1
-          description: The number of failed checks with critial severity
+          description: The number of failed checks with critical severity
         - jsonPath: .report.summary.highCount
           type: integer
           name: High

--- a/docs/cli/getting-started.md
+++ b/docs/cli/getting-started.md
@@ -116,7 +116,7 @@ kubectl get configauditreport -o wide
 <summary>Result</summary>
 
 ```
-NAME                          SCANNER     AGE   CRITIAL   HIGH   MEDIUM   LOW
+NAME                          SCANNER     AGE   CRITICAL   HIGH   MEDIUM   LOW
 replicaset-nginx-78449c65d4   Starboard   75s   0         0      6        7
 ```
 </details>

--- a/docs/cli/getting-started.md
+++ b/docs/cli/getting-started.md
@@ -116,7 +116,7 @@ kubectl get configauditreport -o wide
 <summary>Result</summary>
 
 ```
-NAME                          SCANNER     AGE   CRITICAL   HIGH   MEDIUM   LOW
+NAME                          SCANNER     AGE   CRITICAL  HIGH   MEDIUM   LOW
 replicaset-nginx-78449c65d4   Starboard   75s   0         0      6        7
 ```
 </details>

--- a/docs/operator/getting-started.md
+++ b/docs/operator/getting-started.md
@@ -48,7 +48,7 @@ kubectl get configauditreports -o wide
 <summary>Result</summary>
 
 ```
-NAME                          SCANNER     AGE    CRITIAL   HIGH   MEDIUM   LOW
+NAME                          SCANNER     AGE    CRITICAL   HIGH   MEDIUM   LOW
 replicaset-nginx-78449c65d4   Starboard   2m7s   0         0      6        7
 ```
 </details>

--- a/docs/operator/getting-started.md
+++ b/docs/operator/getting-started.md
@@ -48,7 +48,7 @@ kubectl get configauditreports -o wide
 <summary>Result</summary>
 
 ```
-NAME                          SCANNER     AGE    CRITICAL   HIGH   MEDIUM   LOW
+NAME                          SCANNER     AGE    CRITICAL  HIGH   MEDIUM   LOW
 replicaset-nginx-78449c65d4   Starboard   2m7s   0         0      6        7
 ```
 </details>

--- a/docs/tutorials/writing-custom-configuration-audit-policies.md
+++ b/docs/tutorials/writing-custom-configuration-audit-policies.md
@@ -157,7 +157,7 @@ that's failing:
 
 ```console
 $ kubectl get configauditreport configmap-test -o wide
-NAME             SCANNER     AGE   CRITICAL   HIGH   MEDIUM   LOW
+NAME             SCANNER     AGE   CRITICAL  HIGH   MEDIUM   LOW
 configmap-test   Starboard   24s   0         0      0        1
 ```
 

--- a/docs/tutorials/writing-custom-configuration-audit-policies.md
+++ b/docs/tutorials/writing-custom-configuration-audit-policies.md
@@ -157,7 +157,7 @@ that's failing:
 
 ```console
 $ kubectl get configauditreport configmap-test -o wide
-NAME             SCANNER     AGE   CRITIAL   HIGH   MEDIUM   LOW
+NAME             SCANNER     AGE   CRITICAL   HIGH   MEDIUM   LOW
 configmap-test   Starboard   24s   0         0      0        1
 ```
 


### PR DESCRIPTION
## Description

Critical is spelled incorrectly in a number of places.

```
grep -ril critial |
    xargs sed -i \
        -e 's/CRITIAL/CRITICAL/g' \
        -e 's/Critial/Critical/g' \
        -e 's/critial/critical/g'
```

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/starboard/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/starboard/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
