### PR TITLE
Build Starboard Operator based on Red Hat Universal Base Image 8 Minimal

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -37,7 +37,7 @@ builds:
       - arm
       - arm64
       - s390x
-      - ppc64
+      - ppc64le
     goarm:
       - "7"
   - id: starboard-scanner-aqua
@@ -95,7 +95,7 @@ dockers:
       - "--platform=linux/amd64"
   
   - image_templates:
-      - "docker.io/aquasec/starboard-operator:ubi8-{{ .Version }}-amd64"
+      - "docker.io/aquasec/starboard-operator:{{ .Version }}-ubi8-amd64"
     use: buildx
     goos: linux
     dockerfile: build/starboard-operator-ubi8/Dockerfile.ubi8
@@ -103,7 +103,7 @@ dockers:
     ids:
       - starboard-operator
     build_flag_templates:
-      - "--label=org.opencontainers.image.title=starboard-operator-ubi8"
+      - "--label=org.opencontainers.image.title=starboard-operator"
       - "--label=org.opencontainers.image.description=Keeps Starboard resources updated"
       - "--label=org.opencontainers.image.vendor=Aqua Security"
       - "--label=org.opencontainers.image.version={{ .Version }}"
@@ -169,7 +169,7 @@ dockers:
       - "--platform=linux/arm64"
 
   - image_templates:
-      - "docker.io/aquasec/starboard-operator:ubi8-{{ .Version }}-arm64"
+      - "docker.io/aquasec/starboard-operator:{{ .Version }}-ubi8-arm64"
     use: buildx
     goos: linux
     dockerfile: build/starboard-operator-ubi8/Dockerfile.ubi8
@@ -177,7 +177,7 @@ dockers:
     ids:
       - starboard-operator
     build_flag_templates:
-      - "--label=org.opencontainers.image.title=starboard-operator-ubi8"
+      - "--label=org.opencontainers.image.title=starboard-operator"
       - "--label=org.opencontainers.image.description=Keeps Starboard resources updated"
       - "--label=org.opencontainers.image.vendor=Aqua Security"
       - "--label=org.opencontainers.image.version={{ .Version }}"
@@ -242,7 +242,7 @@ dockers:
       - "--label=org.opencontainers.image.documentation=https://aquasecurity.github.io/starboard/v{{ .Version }}/"
       - "--platform=linux/s390x"
   - image_templates:
-      - "docker.io/aquasec/starboard-operator:ubi8-{{ .Version }}-s390x"
+      - "docker.io/aquasec/starboard-operator:{{ .Version }}-ubi8-s390x"
     use: buildx
     goos: linux
     dockerfile: build/starboard-operator-ubi8/Dockerfile.ubi8
@@ -250,7 +250,7 @@ dockers:
     ids:
       - starboard-operator
     build_flag_templates:
-      - "--label=org.opencontainers.image.title=starboard-operator-ubi8"
+      - "--label=org.opencontainers.image.title=starboard-operator"
       - "--label=org.opencontainers.image.description=Keeps Starboard resources updated"
       - "--label=org.opencontainers.image.vendor=Aqua Security"
       - "--label=org.opencontainers.image.version={{ .Version }}"
@@ -279,15 +279,15 @@ dockers:
       - "--platform=linux/s390x"
 
   - image_templates:
-      - "docker.io/aquasec/starboard-operator:ubi8-{{ .Version }}-ppc64"
+      - "docker.io/aquasec/starboard-operator:{{ .Version }}-ubi8-ppc64le"
     use: buildx
     goos: linux
     dockerfile: build/starboard-operator-ubi8/Dockerfile.ubi8
-    goarch: ppc64
+    goarch: ppc64le
     ids:
       - starboard-operator
     build_flag_templates:
-      - "--label=org.opencontainers.image.title=starboard-operator-ubi8"
+      - "--label=org.opencontainers.image.title=starboard-operator"
       - "--label=org.opencontainers.image.description=Keeps Starboard resources updated"
       - "--label=org.opencontainers.image.vendor=Aqua Security"
       - "--label=org.opencontainers.image.version={{ .Version }}"
@@ -295,7 +295,7 @@ dockers:
       - "--label=org.opencontainers.image.source=https://github.com/aquasecurity/starboard"
       - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
       - "--label=org.opencontainers.image.documentation=https://aquasecurity.github.io/starboard/v{{ .Version }}/"
-      - "--platform=linux/ppc64"
+      - "--platform=linux/ppc64le"
 docker_manifests:
   - name_template: "aquasec/starboard:{{ .Version }}"
     image_templates:
@@ -314,7 +314,7 @@ docker_manifests:
       - "aquasec/starboard-scanner-aqua:{{ .Version }}-s390x"
   - name_template: "aquasec/starboard-operator:ubi8-{{ .Version }}"
     image_templates:
-      - "aquasec/starboard-scanner-aqua:ubi8-{{ .Version }}-amd64"
-      - "aquasec/starboard-scanner-aqua:ubi8-{{ .Version }}-arm64"
-      - "aquasec/starboard-scanner-aqua:ubi8-{{ .Version }}-s390x"
-      - "aquasec/starboard-scanner-aqua:ubi8-{{ .Version }}-ppc64"
+      - "aquasec/starboard-scanner-aqua:{{ .Version }}-ubi8-amd64"
+      - "aquasec/starboard-scanner-aqua:{{ .Version }}-ubi8-arm64"
+      - "aquasec/starboard-scanner-aqua:{{ .Version }}-ubi8-s390x"
+      - "aquasec/starboard-scanner-aqua:{{ .Version }}-ubi8-ppc64le"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -37,6 +37,7 @@ builds:
       - arm
       - arm64
       - s390x
+      - ppc64
     goarm:
       - "7"
   - id: starboard-scanner-aqua
@@ -92,16 +93,17 @@ dockers:
       - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
       - "--label=org.opencontainers.image.documentation=https://aquasecurity.github.io/starboard/v{{ .Version }}/"
       - "--platform=linux/amd64"
+  
   - image_templates:
-      - "docker.io/aquasec/starboard-operator:{{ .Version }}-amd64"
+      - "docker.io/aquasec/starboard-operator:ubi8-{{ .Version }}-amd64"
     use: buildx
     goos: linux
-    dockerfile: build/starboard-operator/Dockerfile
+    dockerfile: build/starboard-operator-ubi8/Dockerfile.ubi8
     goarch: amd64
     ids:
       - starboard-operator
     build_flag_templates:
-      - "--label=org.opencontainers.image.title=starboard-operator"
+      - "--label=org.opencontainers.image.title=starboard-operator-ubi8"
       - "--label=org.opencontainers.image.description=Keeps Starboard resources updated"
       - "--label=org.opencontainers.image.vendor=Aqua Security"
       - "--label=org.opencontainers.image.version={{ .Version }}"
@@ -110,6 +112,7 @@ dockers:
       - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
       - "--label=org.opencontainers.image.documentation=https://aquasecurity.github.io/starboard/v{{ .Version }}/"
       - "--platform=linux/amd64"
+
   - image_templates:
       - "docker.io/aquasec/starboard-scanner-aqua:{{ .Version }}-amd64"
     use: buildx
@@ -164,6 +167,26 @@ dockers:
       - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
       - "--label=org.opencontainers.image.documentation=https://aquasecurity.github.io/starboard/v{{ .Version }}/"
       - "--platform=linux/arm64"
+
+  - image_templates:
+      - "docker.io/aquasec/starboard-operator:ubi8-{{ .Version }}-arm64"
+    use: buildx
+    goos: linux
+    dockerfile: build/starboard-operator-ubi8/Dockerfile.ubi8
+    goarch: amd64
+    ids:
+      - starboard-operator
+    build_flag_templates:
+      - "--label=org.opencontainers.image.title=starboard-operator-ubi8"
+      - "--label=org.opencontainers.image.description=Keeps Starboard resources updated"
+      - "--label=org.opencontainers.image.vendor=Aqua Security"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.created={{ .Date }}"
+      - "--label=org.opencontainers.image.source=https://github.com/aquasecurity/starboard"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.documentation=https://aquasecurity.github.io/starboard/v{{ .Version }}/"
+      - "--platform=linux/arm64"    
+
   - image_templates:
       - "docker.io/aquasec/starboard-scanner-aqua:{{ .Version }}-arm64"
     use: buildx
@@ -219,6 +242,24 @@ dockers:
       - "--label=org.opencontainers.image.documentation=https://aquasecurity.github.io/starboard/v{{ .Version }}/"
       - "--platform=linux/s390x"
   - image_templates:
+      - "docker.io/aquasec/starboard-operator:ubi8-{{ .Version }}-s390x"
+    use: buildx
+    goos: linux
+    dockerfile: build/starboard-operator-ubi8/Dockerfile.ubi8
+    goarch: s390x
+    ids:
+      - starboard-operator
+    build_flag_templates:
+      - "--label=org.opencontainers.image.title=starboard-operator-ubi8"
+      - "--label=org.opencontainers.image.description=Keeps Starboard resources updated"
+      - "--label=org.opencontainers.image.vendor=Aqua Security"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.created={{ .Date }}"
+      - "--label=org.opencontainers.image.source=https://github.com/aquasecurity/starboard"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.documentation=https://aquasecurity.github.io/starboard/v{{ .Version }}/"
+      - "--platform=linux/s390x"
+  - image_templates:
       - "docker.io/aquasec/starboard-scanner-aqua:{{ .Version }}-s390x"
     use: buildx
     goos: linux
@@ -236,6 +277,25 @@ dockers:
       - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
       - "--label=org.opencontainers.image.documentation=https://aquasecurity.github.io/starboard/v{{ .Version }}/"
       - "--platform=linux/s390x"
+
+  - image_templates:
+      - "docker.io/aquasec/starboard-operator:ubi8-{{ .Version }}-ppc64"
+    use: buildx
+    goos: linux
+    dockerfile: build/starboard-operator-ubi8/Dockerfile.ubi8
+    goarch: ppc64
+    ids:
+      - starboard-operator
+    build_flag_templates:
+      - "--label=org.opencontainers.image.title=starboard-operator-ubi8"
+      - "--label=org.opencontainers.image.description=Keeps Starboard resources updated"
+      - "--label=org.opencontainers.image.vendor=Aqua Security"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.created={{ .Date }}"
+      - "--label=org.opencontainers.image.source=https://github.com/aquasecurity/starboard"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.documentation=https://aquasecurity.github.io/starboard/v{{ .Version }}/"
+      - "--platform=linux/ppc64"
 docker_manifests:
   - name_template: "aquasec/starboard:{{ .Version }}"
     image_templates:
@@ -252,3 +312,9 @@ docker_manifests:
       - "aquasec/starboard-scanner-aqua:{{ .Version }}-amd64"
       - "aquasec/starboard-scanner-aqua:{{ .Version }}-arm64"
       - "aquasec/starboard-scanner-aqua:{{ .Version }}-s390x"
+  - name_template: "aquasec/starboard-operator:ubi8-{{ .Version }}"
+    image_templates:
+      - "aquasec/starboard-scanner-aqua:ubi8-{{ .Version }}-amd64"
+      - "aquasec/starboard-scanner-aqua:ubi8-{{ .Version }}-arm64"
+      - "aquasec/starboard-scanner-aqua:ubi8-{{ .Version }}-s390x"
+      - "aquasec/starboard-scanner-aqua:ubi8-{{ .Version }}-ppc64"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -184,7 +184,6 @@ dockers:
       - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
       - "--label=org.opencontainers.image.documentation=https://aquasecurity.github.io/starboard/v{{ .Version }}/"
       - "--platform=linux/arm64"
-
   - image_templates:
       - "docker.io/aquasec/starboard-operator:{{ .Version }}-ubi8-arm64"
     use: buildx
@@ -202,8 +201,7 @@ dockers:
       - "--label=org.opencontainers.image.source=https://github.com/aquasecurity/starboard"
       - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
       - "--label=org.opencontainers.image.documentation=https://aquasecurity.github.io/starboard/v{{ .Version }}/"
-      - "--platform=linux/arm64"    
-
+      - "--platform=linux/arm64"
   - image_templates:
       - "docker.io/aquasec/starboard-scanner-aqua:{{ .Version }}-arm64"
     use: buildx
@@ -294,7 +292,6 @@ dockers:
       - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
       - "--label=org.opencontainers.image.documentation=https://aquasecurity.github.io/starboard/v{{ .Version }}/"
       - "--platform=linux/s390x"
-
   - image_templates:
       - "docker.io/aquasec/starboard-operator:{{ .Version }}-ubi8-ppc64le"
     use: buildx

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -93,7 +93,24 @@ dockers:
       - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
       - "--label=org.opencontainers.image.documentation=https://aquasecurity.github.io/starboard/v{{ .Version }}/"
       - "--platform=linux/amd64"
-  
+  - image_templates:
+      - "docker.io/aquasec/starboard-operator:{{ .Version }}-amd64"
+    use: buildx
+    goos: linux
+    dockerfile: build/starboard-operator/Dockerfile
+    goarch: amd64
+    ids:
+      - starboard-operator
+    build_flag_templates:
+      - "--label=org.opencontainers.image.title=starboard-operator"
+      - "--label=org.opencontainers.image.description=Keeps Starboard resources updated"
+      - "--label=org.opencontainers.image.vendor=Aqua Security"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.created={{ .Date }}"
+      - "--label=org.opencontainers.image.source=https://github.com/aquasecurity/starboard"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.documentation=https://aquasecurity.github.io/starboard/v{{ .Version }}/"
+      - "--platform=linux/amd64"
   - image_templates:
       - "docker.io/aquasec/starboard-operator:{{ .Version }}-ubi8-amd64"
     use: buildx
@@ -312,7 +329,7 @@ docker_manifests:
       - "aquasec/starboard-scanner-aqua:{{ .Version }}-amd64"
       - "aquasec/starboard-scanner-aqua:{{ .Version }}-arm64"
       - "aquasec/starboard-scanner-aqua:{{ .Version }}-s390x"
-  - name_template: "aquasec/starboard-operator:ubi8-{{ .Version }}"
+  - name_template: "aquasec/starboard-operator:{{ .Version }}-ubi8"
     image_templates:
       - "aquasec/starboard-scanner-aqua:{{ .Version }}-ubi8-amd64"
       - "aquasec/starboard-scanner-aqua:{{ .Version }}-ubi8-arm64"

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ IMAGE_TAG := dev
 STARBOARD_CLI_IMAGE := aquasec/starboard:$(IMAGE_TAG)
 STARBOARD_OPERATOR_IMAGE := aquasec/starboard-operator:$(IMAGE_TAG)
 STARBOARD_SCANNER_AQUA_IMAGE := aquasec/starboard-scanner-aqua:$(IMAGE_TAG)
+STARBOARD_OPERATOR_IMAGE_UBI8 := aquasec/starboard-operator:$(IMAGE_TAG)-ubi8
 
 MKDOCS_IMAGE := aquasec/mkdocs-material:starboard
 MKDOCS_PORT := 8000
@@ -123,7 +124,7 @@ clean:
 
 .PHONY: docker-build
 ## Builds Docker images for all binaries
-docker-build: docker-build-starboard-cli docker-build-starboard-operator docker-build-starboard-scanner-aqua
+docker-build: docker-build-starboard-cli docker-build-starboard-operator docker-build-starboard-scanner-aqua docker-build-starboard-operator-ubi8
 
 ## Builds Docker image for Starboard CLI
 docker-build-starboard-cli: build-starboard-cli
@@ -132,6 +133,10 @@ docker-build-starboard-cli: build-starboard-cli
 ## Builds Docker image for Starboard operator
 docker-build-starboard-operator: build-starboard-operator
 	docker build --no-cache -t $(STARBOARD_OPERATOR_IMAGE) -f build/starboard-operator/Dockerfile bin
+	
+## Builds Docker image for Starboard operator ubi8
+docker-build-starboard-operator-ubi8: build-starboard-operator
+	docker build --no-cache -f build/starboard-operator-ubi8/Dockerfile.ubi8 -t $(STARBOARD_OPERATOR_IMAGE_UBI8) bin
 
 ## Builds Docker image for Aqua scanner
 docker-build-starboard-scanner-aqua: build-starboard-scanner-aqua

--- a/build/starboard-operator-ubi8/Dockerfile.ubi8
+++ b/build/starboard-operator-ubi8/Dockerfile.ubi8
@@ -1,14 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal
-
-MAINTAINER admin@aquasec.com
-LABEL com.aquasec.component=starboard-operator
-LABEL product=aquasec
-LABEL com.aquasec.baseimage=registry.access.redhat.com/ubi8/ubi-minimal
-LABEL maintainer="admin@aquasec.com"
-LABEL name="Starboard-Operator ubi8"
-LABEL vendor="Aqua Security Software Ltd."
-LABEL summary="Aqua security Starboard-Operator-ubi8"
-LABEL description="Aqua Security Starboard is a Kubernetes-Native Security toolkit"
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.5
 
 RUN microdnf install yum
 RUN yum install bash-completion -y

--- a/build/starboard-operator-ubi8/Dockerfile.ubi8
+++ b/build/starboard-operator-ubi8/Dockerfile.ubi8
@@ -1,0 +1,21 @@
+FROM registry.access.redhat.com/ubi8/ubi-minimal
+
+MAINTAINER admin@aquasec.com
+LABEL com.aquasec.component=starboard-operator
+LABEL product=aquasec
+LABEL com.aquasec.baseimage=registry.access.redhat.com/ubi8/ubi-minimal
+LABEL maintainer="admin@aquasec.com"
+LABEL name="Starboard-Operator ubi8"
+LABEL vendor="Aqua Security Software Ltd."
+LABEL summary="Aqua security Starboard-Operator-ubi8"
+LABEL description="Aqua Security Starboard is a Kubernetes-Native Security toolkit"
+
+RUN microdnf install yum
+RUN yum install bash-completion -y
+RUN useradd -u 10000 starboard
+WORKDIR /opt/bin/
+COPY starboard-operator /usr/local/bin/starboard-operator
+
+USER starboard
+
+ENTRYPOINT ["starboard-operator"]

--- a/build/starboard-operator-ubi8/Dockerfile.ubi8
+++ b/build/starboard-operator-ubi8/Dockerfile.ubi8
@@ -1,7 +1,6 @@
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.5
 
-RUN microdnf install yum
-RUN yum install bash-completion -y
+RUN microdnf install shadow-utils
 RUN useradd -u 10000 starboard
 WORKDIR /opt/bin/
 COPY starboard-operator /usr/local/bin/starboard-operator


### PR DESCRIPTION
This PR contains changes in the .goreleaser yaml ,  Makefile and addition of Dockerfile with ubi8-minimal as base Image for OCP Certification of Starboard-Operator.