### PR TITLE
feat(trivy): add mirror config in helm chart

### DIFF
--- a/deploy/helm/templates/config.yaml
+++ b/deploy/helm/templates/config.yaml
@@ -62,6 +62,9 @@ data:
   {{- range $key, $registry := .nonSslRegistries }}
   trivy.nonSslRegistry.{{ $key }}: {{ $registry | quote }}
   {{- end }}
+  {{- range $key, $registry := .registry.mirror }}
+  trivy.registry.mirror.{{ $key }}: {{ $registry | quote }}
+  {{- end }}
   trivy.severity: {{ .severity | quote }}
   trivy.dbRepository: {{ .dbRepository | quote }}
   {{- if .ignoreUnfixed }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -124,6 +124,12 @@ trivy:
   #  qaRegistry: qa.registry.aquasec.com
   #  internalRegistry: registry.registry.svc:5000
 
+  # Mirrored registries. There can be multiple registries with different keys.
+  # Make sure to quote registries containing dots
+  registry: 
+    mirror: {}
+    # "docker.io": docker-mirror.example.com
+
   # severity is a comma separated list of severity levels reported by Trivy.
   severity: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL
 


### PR DESCRIPTION
## Description
This patch adds the trivy mirror configuration to the starboard operator
helm chart. This particular implementation is made to match the
definitions from the documentation and therefore uses two layers for the
object and singular terminology.

The patch is required because currently there is no way than post
deployment patching of the configmap in order to utilise this feature,
which works against the intention of helm. It was also very confusing to
find the documentation providing this option, but the helm chart not
doing so, therefore this patch should help to cleanup potential
confusion.

## References:
https://aquasecurity.github.io/starboard/v0.15.4/vulnerability-scanning/trivy/#settings

## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/starboard/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've added usage information (if the PR introduces new options)

