### PR TITLE
Fix: Remove extra space from nsa ClusterComplianceReport manifest to fix yamllint error

### DIFF
--- a/deploy/specs/nsa-1.0.yaml
+++ b/deploy/specs/nsa-1.0.yaml
@@ -74,7 +74,7 @@ spec:
         checks:
           - id: KSV010
       severity: 'HIGH'
-    - name:  Run with root privileges or with root group membership
+    - name: Run with root privileges or with root group membership
       description: 'Controls whether container applications can run with root privileges or with root group membership'
       id: '1.6'
       kinds:

--- a/docs/design/design_compliance_report.md
+++ b/docs/design/design_compliance_report.md
@@ -97,7 +97,7 @@ spec:
         checks:
           - id: KSV010
       severity: 'HIGH'
-    - name:  Run with root privileges or with root group membership
+    - name: Run with root privileges or with root group membership
       description: 'Controls whether container applications can run with root privileges or with root group membership'
       id: '1.6'
       kinds:


### PR DESCRIPTION

Signed-off-by: Luciano Carranza <luchoc@gmail.com>

## Description
Hi! When using the official starboard helm chart and running yammlint against the rendered templates, I'm getting the following error:
```
# yamllint "${MANIFEST}"
1510:13   error    too many spaces after colon  (colons)
```

Linting runs successfully after removing the extra space from the "Run with root privileges or with root group membership" control.