### PR TITLE
Add GCR compatibility

### DIFF
--- a/docs/vulnerability-scanning/managed-registries.md
+++ b/docs/vulnerability-scanning/managed-registries.md
@@ -76,3 +76,28 @@ kubectl -n starboard edit cm starboard
 # validate
 starboard config --get scanJob.podTemplateLabels
 ```
+
+## Google Container Registry (GCR)
+
+You must create Google service account in your GCP console with following roles: `Artifact Registry Reader` and `Storage Object Viewer`. To make this, go to the `APIs & Services -> Credentials`, then click on `Create credentials` button and select Service account in drop-down list. Then you need to create JSON key. To make this, go to the created Service account page, and in `Keys` tab create new JSON key. 
+
+After downloading your Service account's JSON key, you need to create `Secret` with this JSON key in your cluster with Starboard(IMPORTANT: Secret name should be `starboard-trivy-google-creds`):
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: starboard-trivy-google-creds
+  namespace: starboard-system
+data:
+  google-creds.json: <base64_encoded_JSON_key>
+```
+
+After creating `Secret` you need to tell you Starboard deployment to use this credentials:
+
+```
+kubectl patch configmap/starboard-trivy-config \
+  -n starboard-system \
+  --type merge \
+  -p '{"data":{"trivy.googleAppCreds":"google-creds.json"}}'
+```

--- a/docs/vulnerability-scanning/trivy.md
+++ b/docs/vulnerability-scanning/trivy.md
@@ -104,6 +104,7 @@ EOF
 | `trivy.resources.requests.memory`  | `100M`                             | The minimum amount of memory required to run Trivy scanner pod.                                                                                                     |
 | `trivy.resources.limits.cpu`       | `500m`                             | The maximum amount of CPU allowed to run Trivy scanner pod.                                                                                                         |
 | `trivy.resources.limits.memory`    | `500M`                             | The maximum amount of memory allowed to run Trivy scanner pod.                                                                                                      |
+| `trivy.googleAppCreds`             | N/A                                | Name of the file with Google Application Credentials used in `starboard-trivy-google-creds` secrets (if defined)                                                    |
 
 | SECRET KEY                  | DESCRIPTION                                                                                                                       |
 |-----------------------------|-----------------------------------------------------------------------------------------------------------------------------------|

--- a/pkg/plugin/trivy/plugin.go
+++ b/pkg/plugin/trivy/plugin.go
@@ -44,6 +44,7 @@ const (
 	keyTrivySkipFiles              = "trivy.skipFiles"
 	keyTrivySkipDirs               = "trivy.skipDirs"
 	keyTrivyDBRepository           = "trivy.dbRepository"
+	keyTrivyGoogleAppCreds         = "trivy.googleAppCreds"
 
 	keyTrivyServerURL           = "trivy.serverURL"
 	keyTrivyServerTokenHeader   = "trivy.serverTokenHeader"
@@ -132,6 +133,15 @@ func (c Config) GetServerInsecure() bool {
 func (c Config) IgnoreFileExists() bool {
 	_, ok := c.Data[keyTrivyIgnoreFile]
 	return ok
+}
+
+func (c Config) GoogleCredsFileExists() bool {
+	_, ok := c.Data[keyTrivyGoogleAppCreds]
+	return ok
+}
+
+func (c Config) GetGoogleCredsFile() (string, error) {
+	return c.GetRequiredData(keyTrivyGoogleAppCreds)
 }
 
 func (c Config) IgnoreUnfixed() bool {
@@ -314,6 +324,8 @@ const (
 	ignoreFileVolumeName        = "ignorefile"
 	FsSharedVolumeName          = "starboard"
 	SharedVolumeLocationOfTrivy = "/var/starboard/trivy"
+	googleCredsVolumeName       = "google-app-creds"
+	googleCredsSecretName       = "starboard-trivy-google-creds"
 )
 
 // In the Standalone mode there is the init container responsible for
@@ -456,6 +468,23 @@ func (p *plugin) getPodSpecForStandaloneMode(ctx starboard.PluginContext, config
 		},
 	}
 
+	if config.GoogleCredsFileExists() {
+		volumes = append(volumes, corev1.Volume{
+			Name: googleCredsVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: googleCredsSecretName,
+				},
+			},
+		})
+
+		volumeMounts = append(volumeMounts, corev1.VolumeMount{
+			Name:      googleCredsVolumeName,
+			ReadOnly:  true,
+			MountPath: "/tmp/google-creds",
+		})
+	}
+
 	if config.IgnoreFileExists() {
 		volumes = append(volumes, corev1.Volume{
 			Name: ignoreFileVolumeName,
@@ -580,6 +609,15 @@ func (p *plugin) getPodSpecForStandaloneMode(ctx starboard.PluginContext, config
 					},
 				},
 			},
+		}
+
+		if config.GoogleCredsFileExists() {
+			googleCredsEnv, _ := config.GetGoogleCredsFile()
+			googleCredsEnv = "/tmp/google-creds/" + googleCredsEnv
+			env = append(env, corev1.EnvVar{
+				Name:  "GOOGLE_APPLICATION_CREDENTIALS",
+				Value: googleCredsEnv,
+			})
 		}
 
 		if config.IgnoreFileExists() {
@@ -881,6 +919,15 @@ func (p *plugin) getPodSpecForClientServerMode(ctx starboard.PluginContext, conf
 			})
 		}
 
+		if config.GoogleCredsFileExists() {
+			googleCredsEnv, _ := config.GetGoogleCredsFile()
+			googleCredsEnv = "/tmp/google-creds/" + googleCredsEnv
+			env = append(env, corev1.EnvVar{
+				Name:  "GOOGLE_APPLICATION_CREDENTIALS",
+				Value: googleCredsEnv,
+			})
+		}
+
 		env, err = p.appendTrivyInsecureEnv(config, container.Image, env)
 		if err != nil {
 			return corev1.PodSpec{}, nil, err
@@ -895,6 +942,23 @@ func (p *plugin) getPodSpecForClientServerMode(ctx starboard.PluginContext, conf
 			env = append(env, corev1.EnvVar{
 				Name:  "TRIVY_INSECURE",
 				Value: "true",
+			})
+		}
+
+		if config.GoogleCredsFileExists() {
+			volumes = append(volumes, corev1.Volume{
+				Name: googleCredsVolumeName,
+				VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{
+						SecretName: googleCredsSecretName,
+					},
+				},
+			})
+	
+			volumeMounts = append(volumeMounts, corev1.VolumeMount{
+				Name:      googleCredsVolumeName,
+				ReadOnly:  true,
+				MountPath: "/tmp/google-creds",
 			})
 		}
 

--- a/pkg/plugin/trivy/plugin_test.go
+++ b/pkg/plugin/trivy/plugin_test.go
@@ -437,6 +437,41 @@ func TestConfig_GetMirrors(t *testing.T) {
 	}
 }
 
+func TestConfig_GoogleCredsFileExists(t *testing.T) {
+	testCases := []struct {
+		name           string
+		configData     trivy.Config
+		expectedOutput bool
+	}{
+		{
+			name: "Should return false",
+			configData: trivy.Config{PluginConfig: starboard.PluginConfig{
+				Data: map[string]string{
+					"foo": "bar",
+				},
+			}},
+			expectedOutput: false,
+		},
+		{
+			name: "Should return true",
+			configData: trivy.Config{PluginConfig: starboard.PluginConfig{
+				Data: map[string]string{
+					"foo":                  "bar",
+					"trivy.googleAppCreds": "google-creds.json",
+				},
+			}},
+			expectedOutput: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			exists := tc.configData.GoogleCredsFileExists()
+			assert.Equal(t, tc.expectedOutput, exists)
+		})
+	}
+}
+
 func TestPlugin_Init(t *testing.T) {
 
 	t.Run("Should create the default config", func(t *testing.T) {


### PR DESCRIPTION
## Description
This PR include GCR compatibility for Starboard operator. Basically, what you need to do to make Trivy scan images from GCR is to add `GOOGLE_APPLICATION_CREDENTIALS` environment variable with value that equals to path to Service Account json file. With this changes you can easily make vulnerability scan jobs actually scan images from GCR.

## Related issues
- Close #120 (Initial problem was about GCR)
- Close #1189


## Checklist
- [x] I've read the [guidelines for contributing](https://github.com/aquasecurity/starboard/blob/main/CONTRIBUTING.md) to this repository.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [x] I've updated the [documentation](https://github.com/aquasecurity/starboard/tree/main/docs) with the relevant information (if needed).
- [x] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
