### PR TITLE
Using latest tag everytime for ubi-minimal

### DIFF
--- a/build/starboard-operator/Dockerfile.ubi8
+++ b/build/starboard-operator/Dockerfile.ubi8
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.5
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 
 LABEL name="Starboard" \
       vendor="Aqua Security Software Ltd." \


### PR DESCRIPTION
Instead of using specific tag from ubi-minimal will use latest tag everytime. So all time will have all latest packages with fixed vulnerabilities.

Note: with ubi-minimal:8.5 we are seeing vulnerabilities.

