### PR TITLE
chore: release fips enabled images

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -40,6 +40,21 @@ builds:
       - ppc64le
     goarm:
       - "7"
+  - id: starboard-operator-fips
+    main: ./cmd/starboard-operator/main.go
+    binary: starboard-operator-fips
+    flags:
+      - -tags=fipsonly
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm
+      - arm64
+      - s390x
+      - ppc64le
+    goarm:
+      - "7"
   - id: starboard-scanner-aqua
     main: ./cmd/scanner-aqua/main.go
     binary: starboard-scanner-aqua
@@ -53,13 +68,15 @@ builds:
     goarm:
       - "7"
 archives:
-  - name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
+  - name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "arm" }}ARM
+      {{- else if eq .Arch "arm64" }}ARM64
+      {{- else }}{{ .Arch }}{{ end }}
     builds:
       - starboard
-    replacements:
-      amd64: x86_64
-      arm: ARM
-      arm64: ARM64
     format_overrides:
       - goos: windows
         format: zip
@@ -335,6 +352,86 @@ dockers:
       - "--platform=linux/ppc64le"
     extra_files:
       - LICENSE
+  - image_templates:
+      - "docker.io/aquasec/starboard-operator:{{ .Version }}-ubi8-fips-amd64"
+    use: buildx
+    goos: linux
+    dockerfile: build/starboard-operator/Dockerfile.fips.ubi8
+    goarch: amd64
+    ids:
+      - starboard-operator-fips
+    build_flag_templates:
+      - "--label=org.opencontainers.image.title=starboard-operator"
+      - "--label=org.opencontainers.image.description=Keeps Starboard resources updated"
+      - "--label=org.opencontainers.image.vendor=Aqua Security"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.created={{ .Date }}"
+      - "--label=org.opencontainers.image.source=https://github.com/aquasecurity/starboard"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.documentation=https://aquasecurity.github.io/starboard/v{{ .Version }}/"
+      - "--platform=linux/amd64"
+    extra_files:
+      - LICENSE
+  - image_templates:
+      - "docker.io/aquasec/starboard-operator:{{ .Version }}-ubi8-fips-arm64"
+    use: buildx
+    goos: linux
+    dockerfile: build/starboard-operator/Dockerfile.fips.ubi8
+    goarch: arm64
+    ids:
+      - starboard-operator-fips
+    build_flag_templates:
+      - "--label=org.opencontainers.image.title=starboard-operator"
+      - "--label=org.opencontainers.image.description=Keeps Starboard resources updated"
+      - "--label=org.opencontainers.image.vendor=Aqua Security"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.created={{ .Date }}"
+      - "--label=org.opencontainers.image.source=https://github.com/aquasecurity/starboard"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.documentation=https://aquasecurity.github.io/starboard/v{{ .Version }}/"
+      - "--platform=linux/arm64"
+    extra_files:
+      - LICENSE
+  - image_templates:
+      - "docker.io/aquasec/starboard-operator:{{ .Version }}-ubi8-fips-s390x"
+    use: buildx
+    goos: linux
+    dockerfile: build/starboard-operator/Dockerfile.fips.ubi8
+    goarch: s390x
+    ids:
+      - starboard-operator-fips
+    build_flag_templates:
+      - "--label=org.opencontainers.image.title=starboard-operator"
+      - "--label=org.opencontainers.image.description=Keeps Starboard resources updated"
+      - "--label=org.opencontainers.image.vendor=Aqua Security"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.created={{ .Date }}"
+      - "--label=org.opencontainers.image.source=https://github.com/aquasecurity/starboard"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.documentation=https://aquasecurity.github.io/starboard/v{{ .Version }}/"
+      - "--platform=linux/s390x"
+    extra_files:
+      - LICENSE
+  - image_templates:
+      - "docker.io/aquasec/starboard-operator:{{ .Version }}-ubi8-fips-ppc64le"
+    use: buildx
+    goos: linux
+    dockerfile: build/starboard-operator/Dockerfile.fips.ubi8
+    goarch: ppc64le
+    ids:
+      - starboard-operator-fips
+    build_flag_templates:
+      - "--label=org.opencontainers.image.title=starboard-operator"
+      - "--label=org.opencontainers.image.description=Keeps Starboard resources updated"
+      - "--label=org.opencontainers.image.vendor=Aqua Security"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.created={{ .Date }}"
+      - "--label=org.opencontainers.image.source=https://github.com/aquasecurity/starboard"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.documentation=https://aquasecurity.github.io/starboard/v{{ .Version }}/"
+      - "--platform=linux/ppc64le"
+    extra_files:
+      - LICENSE
 docker_manifests:
   - name_template: "aquasec/starboard:{{ .Version }}"
     image_templates:
@@ -353,6 +450,12 @@ docker_manifests:
       - "aquasec/starboard-operator:{{ .Version }}-ubi8-arm64"
       - "aquasec/starboard-operator:{{ .Version }}-ubi8-s390x"
       - "aquasec/starboard-operator:{{ .Version }}-ubi8-ppc64le"
+  - name_template: "aquasec/starboard-operator:{{ .Version }}-ubi8-fips"
+    image_templates:
+      - "aquasec/starboard-operator:{{ .Version }}-ubi8-fips-amd64"
+      - "aquasec/starboard-operator:{{ .Version }}-ubi8-fips-arm64"
+      - "aquasec/starboard-operator:{{ .Version }}-ubi8-fips-s390x"
+      - "aquasec/starboard-operator:{{ .Version }}-ubi8-fips-ppc64le"
   - name_template: "aquasec/starboard-scanner-aqua:{{ .Version }}"
     image_templates:
       - "aquasec/starboard-scanner-aqua:{{ .Version }}-amd64"

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ STARBOARD_CLI_IMAGE := aquasec/starboard:$(IMAGE_TAG)
 STARBOARD_OPERATOR_IMAGE := aquasec/starboard-operator:$(IMAGE_TAG)
 STARBOARD_SCANNER_AQUA_IMAGE := aquasec/starboard-scanner-aqua:$(IMAGE_TAG)
 STARBOARD_OPERATOR_IMAGE_UBI8 := aquasec/starboard-operator:$(IMAGE_TAG)-ubi8
+STARBOARD_OPERATOR_IMAGE_UBI8_FIPS := aquasec/starboard-operator:$(IMAGE_TAG)-ubi8-fips
 
 MKDOCS_IMAGE := aquasec/mkdocs-material:starboard
 MKDOCS_PORT := 8000
@@ -37,6 +38,10 @@ build-starboard-cli: $(SOURCES)
 ## Builds the starboard-operator binary
 build-starboard-operator: $(SOURCES)
 	CGO_ENABLED=0 GOOS=linux go build -o ./bin/starboard-operator ./cmd/starboard-operator/main.go
+
+## Builds the starboard-operator binary
+build-starboard-operator-fips: $(SOURCES)
+	CGO_ENABLED=0 GOOS=linux GOEXPERIMENT=boringcrypto go build -tags fipsonly -o ./bin/starboard-operator-fips ./cmd/starboard-operator/main.go
 
 ## Builds the scanner-aqua binary
 build-starboard-scanner-aqua: $(SOURCES)
@@ -139,7 +144,11 @@ docker-build-starboard-cli: build-starboard-cli
 ## Builds Docker image for Starboard operator
 docker-build-starboard-operator: build-starboard-operator
 	$(DOCKER) build --no-cache -t $(STARBOARD_OPERATOR_IMAGE) -f build/starboard-operator/Dockerfile bin
-	
+
+## Builds Docker image for Starboard operator ubi8
+docker-build-starboard-operator-fips: build-starboard-operator-fips
+	$(DOCKER) build --no-cache -f build/starboard-operator/Dockerfile.fips.ubi8 -t $(STARBOARD_OPERATOR_IMAGE_UBI8_FIPS) bin
+
 ## Builds Docker image for Starboard operator ubi8
 docker-build-starboard-operator-ubi8: build-starboard-operator
 	$(DOCKER) build --no-cache -f build/starboard-operator/Dockerfile.ubi8 -t $(STARBOARD_OPERATOR_IMAGE_UBI8) bin

--- a/build/starboard-operator/Dockerfile.fips.ubi8
+++ b/build/starboard-operator/Dockerfile.fips.ubi8
@@ -1,0 +1,16 @@
+FROM registry.access.redhat.com/ubi8/ubi-minimal
+
+LABEL name="Starboard" \
+      vendor="Aqua Security Software Ltd." \
+      version="v0.15.13" \
+      summary="Starboard Operator."
+
+RUN microdnf install shadow-utils
+RUN useradd -u 10000 starboard
+WORKDIR /opt/bin/
+COPY starboard-operator-fips /usr/local/bin/starboard-operator
+COPY LICENSE /licenses/LICENSE
+
+USER starboard
+
+ENTRYPOINT ["starboard-operator"]

--- a/cmd/starboard-operator/fipsonly.go
+++ b/cmd/starboard-operator/fipsonly.go
@@ -1,0 +1,7 @@
+//go:build fipsonly
+
+package tls
+
+import (
+	_ "crypto/tls/fipsonly"
+)


### PR DESCRIPTION
As part of this PR, we are adding support for fips enabled images which is needed for fips compliance This PR has following changes
- Add docker file for fips enabled image
- Add makefile commands to generate fips enabled binary
- Add goreleaser support to release starboard-operator with fips enable image
- fix deprecated parameter from goreleaser i.e Replacements
