### PR TITLE
fix: Fix crd names error for roles

### DIFF
--- a/pkg/configauditreport/builder.go
+++ b/pkg/configauditreport/builder.go
@@ -191,8 +191,8 @@ func (b *ReportBuilder) Data(data v1alpha1.ConfigAuditReportData) *ReportBuilder
 func (b *ReportBuilder) reportName() string {
 	kind := b.controller.GetObjectKind().GroupVersionKind().Kind
 	name := b.controller.GetName()
-	reportName := fmt.Sprintf("%s-%s", strings.ToLower(kind), strings.ToLower(name))
-	if len(validation.IsValidLabelValue(reportName)) == 0 {
+	reportName := fmt.Sprintf("%s-%s", strings.ToLower(kind), name)
+	if len(validation.IsDNS1123Label(reportName)) == 0 {
 		return reportName
 	}
 	return fmt.Sprintf("%s-%s", strings.ToLower(kind), kube.ComputeHash(name))


### PR DESCRIPTION
roles can have different chars which are not supported in crd names eg '_', capital letter

previous fix was only handling capital letter, this fix will handle other usecases as well.

fixes: #1355
