### PR TITLE
chore: Add ubi9 images for starboard-operator

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -149,6 +149,26 @@ dockers:
     extra_files:
       - LICENSE
   - image_templates:
+      - "docker.io/aquasec/starboard-operator:{{ .Version }}-ubi9-amd64"
+    use: buildx
+    goos: linux
+    dockerfile: build/starboard-operator/Dockerfile.ubi9
+    goarch: amd64
+    ids:
+      - starboard-operator
+    build_flag_templates:
+      - "--label=org.opencontainers.image.title=starboard-operator"
+      - "--label=org.opencontainers.image.description=Keeps Starboard resources updated"
+      - "--label=org.opencontainers.image.vendor=Aqua Security"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.created={{ .Date }}"
+      - "--label=org.opencontainers.image.source=https://github.com/aquasecurity/starboard"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.documentation=https://aquasecurity.github.io/starboard/v{{ .Version }}/"
+      - "--platform=linux/amd64"
+    extra_files:
+      - LICENSE
+  - image_templates:
       - "docker.io/aquasec/starboard-scanner-aqua:{{ .Version }}-amd64"
     use: buildx
     goos: linux
@@ -207,6 +227,26 @@ dockers:
     use: buildx
     goos: linux
     dockerfile: build/starboard-operator/Dockerfile.ubi8
+    goarch: arm64
+    ids:
+      - starboard-operator
+    build_flag_templates:
+      - "--label=org.opencontainers.image.title=starboard-operator"
+      - "--label=org.opencontainers.image.description=Keeps Starboard resources updated"
+      - "--label=org.opencontainers.image.vendor=Aqua Security"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.created={{ .Date }}"
+      - "--label=org.opencontainers.image.source=https://github.com/aquasecurity/starboard"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.documentation=https://aquasecurity.github.io/starboard/v{{ .Version }}/"
+      - "--platform=linux/arm64"
+    extra_files:
+      - LICENSE
+  - image_templates:
+      - "docker.io/aquasec/starboard-operator:{{ .Version }}-ubi9-arm64"
+    use: buildx
+    goos: linux
+    dockerfile: build/starboard-operator/Dockerfile.ubi9
     goarch: arm64
     ids:
       - starboard-operator
@@ -315,6 +355,26 @@ dockers:
     extra_files:
       - LICENSE
   - image_templates:
+      - "docker.io/aquasec/starboard-operator:{{ .Version }}-ubi9-s390x"
+    use: buildx
+    goos: linux
+    dockerfile: build/starboard-operator/Dockerfile.ubi9
+    goarch: s390x
+    ids:
+      - starboard-operator
+    build_flag_templates:
+      - "--label=org.opencontainers.image.title=starboard-operator"
+      - "--label=org.opencontainers.image.description=Keeps Starboard resources updated"
+      - "--label=org.opencontainers.image.vendor=Aqua Security"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.created={{ .Date }}"
+      - "--label=org.opencontainers.image.source=https://github.com/aquasecurity/starboard"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.documentation=https://aquasecurity.github.io/starboard/v{{ .Version }}/"
+      - "--platform=linux/s390x"
+    extra_files:
+      - LICENSE
+  - image_templates:
       - "docker.io/aquasec/starboard-scanner-aqua:{{ .Version }}-s390x"
     use: buildx
     goos: linux
@@ -357,6 +417,26 @@ dockers:
     use: buildx
     goos: linux
     dockerfile: build/starboard-operator/Dockerfile.fips.ubi8
+    goarch: amd64
+    ids:
+      - starboard-operator-fips
+    build_flag_templates:
+      - "--label=org.opencontainers.image.title=starboard-operator"
+      - "--label=org.opencontainers.image.description=Keeps Starboard resources updated"
+      - "--label=org.opencontainers.image.vendor=Aqua Security"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.created={{ .Date }}"
+      - "--label=org.opencontainers.image.source=https://github.com/aquasecurity/starboard"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.documentation=https://aquasecurity.github.io/starboard/v{{ .Version }}/"
+      - "--platform=linux/amd64"
+    extra_files:
+      - LICENSE
+  - image_templates:
+      - "docker.io/aquasec/starboard-operator:{{ .Version }}-ubi9-fips-amd64"
+    use: buildx
+    goos: linux
+    dockerfile: build/starboard-operator/Dockerfile.fips.ubi9
     goarch: amd64
     ids:
       - starboard-operator-fips
@@ -432,6 +512,86 @@ dockers:
       - "--platform=linux/ppc64le"
     extra_files:
       - LICENSE
+  - image_templates:
+      - "docker.io/aquasec/starboard-operator:{{ .Version }}-ubi9-fips-amd64"
+    use: buildx
+    goos: linux
+    dockerfile: build/starboard-operator/Dockerfile.fips.ubi9
+    goarch: amd64
+    ids:
+      - starboard-operator-fips
+    build_flag_templates:
+      - "--label=org.opencontainers.image.title=starboard-operator"
+      - "--label=org.opencontainers.image.description=Keeps Starboard resources updated"
+      - "--label=org.opencontainers.image.vendor=Aqua Security"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.created={{ .Date }}"
+      - "--label=org.opencontainers.image.source=https://github.com/aquasecurity/starboard"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.documentation=https://aquasecurity.github.io/starboard/v{{ .Version }}/"
+      - "--platform=linux/amd64"
+    extra_files:
+      - LICENSE
+  - image_templates:
+      - "docker.io/aquasec/starboard-operator:{{ .Version }}-ubi9-fips-arm64"
+    use: buildx
+    goos: linux
+    dockerfile: build/starboard-operator/Dockerfile.fips.ubi9
+    goarch: arm64
+    ids:
+      - starboard-operator-fips
+    build_flag_templates:
+      - "--label=org.opencontainers.image.title=starboard-operator"
+      - "--label=org.opencontainers.image.description=Keeps Starboard resources updated"
+      - "--label=org.opencontainers.image.vendor=Aqua Security"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.created={{ .Date }}"
+      - "--label=org.opencontainers.image.source=https://github.com/aquasecurity/starboard"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.documentation=https://aquasecurity.github.io/starboard/v{{ .Version }}/"
+      - "--platform=linux/arm64"
+    extra_files:
+      - LICENSE
+  - image_templates:
+      - "docker.io/aquasec/starboard-operator:{{ .Version }}-ubi9-fips-s390x"
+    use: buildx
+    goos: linux
+    dockerfile: build/starboard-operator/Dockerfile.fips.ubi9
+    goarch: s390x
+    ids:
+      - starboard-operator-fips
+    build_flag_templates:
+      - "--label=org.opencontainers.image.title=starboard-operator"
+      - "--label=org.opencontainers.image.description=Keeps Starboard resources updated"
+      - "--label=org.opencontainers.image.vendor=Aqua Security"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.created={{ .Date }}"
+      - "--label=org.opencontainers.image.source=https://github.com/aquasecurity/starboard"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.documentation=https://aquasecurity.github.io/starboard/v{{ .Version }}/"
+      - "--platform=linux/s390x"
+    extra_files:
+      - LICENSE
+  - image_templates:
+      - "docker.io/aquasec/starboard-operator:{{ .Version }}-ubi9-fips-ppc64le"
+    use: buildx
+    goos: linux
+    dockerfile: build/starboard-operator/Dockerfile.fips.ubi9
+    goarch: ppc64le
+    ids:
+      - starboard-operator-fips
+    build_flag_templates:
+      - "--label=org.opencontainers.image.title=starboard-operator"
+      - "--label=org.opencontainers.image.description=Keeps Starboard resources updated"
+      - "--label=org.opencontainers.image.vendor=Aqua Security"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.created={{ .Date }}"
+      - "--label=org.opencontainers.image.source=https://github.com/aquasecurity/starboard"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.documentation=https://aquasecurity.github.io/starboard/v{{ .Version }}/"
+      - "--platform=linux/ppc64le"
+    extra_files:
+      - LICENSE
 docker_manifests:
   - name_template: "aquasec/starboard:{{ .Version }}"
     image_templates:
@@ -456,6 +616,18 @@ docker_manifests:
       - "aquasec/starboard-operator:{{ .Version }}-ubi8-fips-arm64"
       - "aquasec/starboard-operator:{{ .Version }}-ubi8-fips-s390x"
       - "aquasec/starboard-operator:{{ .Version }}-ubi8-fips-ppc64le"
+  - name_template: "aquasec/starboard-operator:{{ .Version }}-ubi9"
+    image_templates:
+      - "aquasec/starboard-operator:{{ .Version }}-ubi9-amd64"
+      - "aquasec/starboard-operator:{{ .Version }}-ubi9-arm64"
+      - "aquasec/starboard-operator:{{ .Version }}-ubi9-s390x"
+      - "aquasec/starboard-operator:{{ .Version }}-ubi9-ppc64le"
+  - name_template: "aquasec/starboard-operator:{{ .Version }}-ubi9-fips"
+    image_templates:
+      - "aquasec/starboard-operator:{{ .Version }}-ubi9-fips-amd64"
+      - "aquasec/starboard-operator:{{ .Version }}-ubi9-fips-arm64"
+      - "aquasec/starboard-operator:{{ .Version }}-ubi9-fips-s390x"
+      - "aquasec/starboard-operator:{{ .Version }}-ubi9-fips-ppc64le"
   - name_template: "aquasec/starboard-scanner-aqua:{{ .Version }}"
     image_templates:
       - "aquasec/starboard-scanner-aqua:{{ .Version }}-amd64"

--- a/build/starboard-operator/Dockerfile.fips.ubi9
+++ b/build/starboard-operator/Dockerfile.fips.ubi9
@@ -1,0 +1,16 @@
+FROM registry.access.redhat.com/ubi9/ubi-minimal
+
+LABEL name="Starboard" \
+      vendor="Aqua Security Software Ltd." \
+      version="v0.15.19" \
+      summary="Starboard Operator."
+
+RUN microdnf install shadow-utils
+RUN useradd -u 10000 starboard
+WORKDIR /opt/bin/
+COPY starboard-operator-fips /usr/local/bin/starboard-operator
+COPY LICENSE /licenses/LICENSE
+
+USER starboard
+
+ENTRYPOINT ["starboard-operator"]

--- a/build/starboard-operator/Dockerfile.ubi9
+++ b/build/starboard-operator/Dockerfile.ubi9
@@ -1,0 +1,16 @@
+FROM registry.access.redhat.com/ubi9/ubi-minimal
+
+LABEL name="Starboard" \
+      vendor="Aqua Security Software Ltd." \
+      version="v0.15.19" \
+      summary="Starboard Operator."
+
+RUN microdnf install shadow-utils
+RUN useradd -u 10000 starboard
+WORKDIR /opt/bin/
+COPY starboard-operator /usr/local/bin/starboard-operator
+COPY LICENSE /licenses/LICENSE
+
+USER starboard
+
+ENTRYPOINT ["starboard-operator"]


### PR DESCRIPTION
As part of this PR, new images will be build using ubi9 as base image. 

We will continue to have ubi8 images until we deprecate them fully

