### PR TITLE
chore: update GoReleaser to v1.23.0 to support windows/arm64

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -166,8 +166,8 @@ jobs:
       - name: Release
         uses: goreleaser/goreleaser-action@v3
         with:
-          version: v1.7.0
-          args: release --rm-dist
+          version: v1.23.0
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
    #   - name: Update new version for plugin 'starboard' in krew-index


### PR DESCRIPTION
To resolve the following warning.

https://github.com/aquasecurity/starboard/actions/runs/7774726668/job/21199969973#step:8:30

```
      • DEPRECATED: skipped windows/arm64 build on Go < 1.17 for compatibility, check https://goreleaser.com/deprecations/#builds-for-windowsarm64 for more info.
```

https://goreleaser.com/deprecations/#builds-for-windowsarm64

## Description

## Related issues
- Close #XXX

Remove this section if you don't have related PRs.

## Checklist
- [ ] I've read the [guidelines for contributing](https://github.com/aquasecurity/starboard/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/starboard/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
