### PR TITLE
Fix broken links README.md to point to new relevant locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 We've announced our plans to discontinue Starboard and merge it into [Trivy](https://github.com/aquasecurity/trivy).
 
-Starboard CLI has been reintroduced as [trivy kubernetes](https://aquasecurity.github.io/trivy/latest/docs/kubernetes/cli/scanning/) command and starboard-operator with a focus on trivy capabilities is available as [Trivy-Operator](https://aquasecurity.github.io/trivy/latest/docs/kubernetes/operator/).
+Starboard CLI has been reintroduced as [trivy kubernetes](https://aquasecurity.github.io/trivy/latest/docs/target/kubernetes/) command and starboard-operator with a focus on trivy capabilities is available as [Trivy-Operator](https://github.com/aquasecurity/trivy-operator).
 
 We will not be accepting new features/pull requests/issues.
 we encourage you to contribute to [Trivy-Operator](https://github.com/aquasecurity/trivy-operator) and [Trivy CLI](https://github.com/aquasecurity/trivy) and influence the future of Trivy Kubernetes.


### PR DESCRIPTION
Fix broken links (404) to point to relevant new locations

## Description
Two links in the ReadMe are returning 404 responses

## Related issues
- I didn't raise an issue

Remove this section if you don't have related PRs.
