### PR TITLE
perf: Exclude kube-bench pods from being evaluated in the starboard

### DIFF
--- a/pkg/configauditreport/controller.go
+++ b/pkg/configauditreport/controller.go
@@ -84,6 +84,7 @@ func (r *ResourceController) SetupWithManager(mgr ctrl.Manager) error {
 				predicate.Not(predicate.ManagedByStarboardOperator),
 				predicate.Not(predicate.IsLeaderElectionResource),
 				predicate.Not(predicate.IsBeingTerminated),
+				predicate.Not(predicate.ManagedByKubeEnforcer),
 				installModePredicate,
 			)).
 			Owns(resource.ownsObject).
@@ -110,6 +111,7 @@ func (r *ResourceController) SetupWithManager(mgr ctrl.Manager) error {
 		err = ctrl.NewControllerManagedBy(mgr).
 			For(resource.forObject, builder.WithPredicates(
 				predicate.Not(predicate.ManagedByStarboardOperator),
+				predicate.Not(predicate.ManagedByKubeEnforcer),
 				predicate.Not(predicate.IsBeingTerminated),
 			)).
 			Owns(resource.ownsObject).

--- a/pkg/operator/predicate/predicate.go
+++ b/pkg/operator/predicate/predicate.go
@@ -89,6 +89,16 @@ var ManagedByStarboardOperator = predicate.NewPredicateFuncs(func(obj client.Obj
 	return false
 })
 
+var ManagedByKubeEnforcer = predicate.NewPredicateFuncs(func(obj client.Object) bool {
+	if managedBy, ok := obj.GetLabels()["app.kubernetes.io/managed-by"]; ok {
+		return managedBy == "KubeEnforcer"
+	}
+	if app, ok := obj.GetLabels()["app"]; ok {
+		return app == "kube-bench"
+	}
+	return false
+})
+
 // IsBeingTerminated is a predicate.Predicate that returns true if the specified
 // client.Object is being terminated, i.e. its DeletionTimestamp property is set to non nil value.
 var IsBeingTerminated = predicate.NewPredicateFuncs(func(obj client.Object) bool {

--- a/pkg/operator/predicate/predicate_test.go
+++ b/pkg/operator/predicate/predicate_test.go
@@ -367,6 +367,59 @@ var _ = Describe("Predicate", func() {
 		})
 	})
 
+	Describe("When checking a ManagedByKubeEnforcer predicate", func() {
+		instance := predicate.ManagedByKubeEnforcer
+
+		Context("Where object is managed by KubeEnforcer", func() {
+			It("Should return true", func() {
+				obj := &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							"app.kubernetes.io/managed-by": "KubeEnforcer",
+						},
+					},
+				}
+
+				Expect(instance.Create(event.CreateEvent{Object: obj})).To(BeTrue())
+				Expect(instance.Update(event.UpdateEvent{ObjectNew: obj})).To(BeTrue())
+				Expect(instance.Delete(event.DeleteEvent{Object: obj})).To(BeTrue())
+				Expect(instance.Generic(event.GenericEvent{Object: obj})).To(BeTrue())
+			})
+		})
+
+		Context("Where object is managed by foo app", func() {
+			It("Should return false", func() {
+				obj := &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							"app.kubernetes.io/managed-by": "foo",
+						},
+					},
+				}
+
+				Expect(instance.Create(event.CreateEvent{Object: obj})).To(BeFalse())
+				Expect(instance.Update(event.UpdateEvent{ObjectNew: obj})).To(BeFalse())
+				Expect(instance.Delete(event.DeleteEvent{Object: obj})).To(BeFalse())
+				Expect(instance.Generic(event.GenericEvent{Object: obj})).To(BeFalse())
+			})
+		})
+
+		Context("Where object is not managed by any app", func() {
+			It("Should return false", func() {
+				obj := &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{},
+					},
+				}
+
+				Expect(instance.Create(event.CreateEvent{Object: obj})).To(BeFalse())
+				Expect(instance.Update(event.UpdateEvent{ObjectNew: obj})).To(BeFalse())
+				Expect(instance.Delete(event.DeleteEvent{Object: obj})).To(BeFalse())
+				Expect(instance.Generic(event.GenericEvent{Object: obj})).To(BeFalse())
+			})
+		})
+	})
+
 	Describe("When checking a Not predicate", func() {
 		Context("Where input predicate returns true", func() {
 			It("Should return false", func() {


### PR DESCRIPTION
In a scaled 800-node cluster, running the starboard-operator with KE results in 1600 pods being created for kube-bench. Since kube-bench is an internal Aqua component, its evaluation can be safely skipped. By excluding kube-bench from the starboard-operator's scope, we can reduce the overall memory consumption of the starboard-operator, optimizing its performance in large-scale environments.