### PR TITLE
DEVOPS-972: Starboard images fail on Redhat cert preflight checks due…

### DIFF
--- a/build/starboard-operator/Dockerfile.ubi9
+++ b/build/starboard-operator/Dockerfile.ubi9
@@ -4,6 +4,10 @@ LABEL name="Starboard" \
       vendor="Aqua Security Software Ltd." \
       version="v0.15.24" \
       summary="Starboard Operator."
+      org.label-schema.schema-version="1.0" \
+      maintainer="Aqua Security Software Ltd." \
+      release=$KUBEBENCH_VERSION \
+      description="Starboard Operator."
 
 RUN microdnf install -y shadow-utils
 RUN useradd -u 10000 starboard

--- a/build/starboard-operator/Dockerfile.ubi9
+++ b/build/starboard-operator/Dockerfile.ubi9
@@ -3,7 +3,7 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal
 LABEL name="Starboard" \
       vendor="Aqua Security Software Ltd." \
       version="v0.15.24" \
-      summary="Starboard Operator."
+      summary="Starboard Operator." \
       org.label-schema.schema-version="1.0" \
       maintainer="Aqua Security Software Ltd." \
       release=$KUBEBENCH_VERSION \


### PR DESCRIPTION
… to migging labels

## Description

## Related issues
- Close #XXX

Remove this section if you don't have related PRs.

## Checklist
- [ ] I've read the [guidelines for contributing](https://github.com/aquasecurity/starboard/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/starboard/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
