### PR TITLE
DEVOPS-972: Starboard images fail on Redhat cert preflight checks due…

### DIFF
--- a/build/starboard-operator/Dockerfile.ubi9
+++ b/build/starboard-operator/Dockerfile.ubi9
@@ -6,7 +6,7 @@ LABEL name="Starboard" \
       summary="Starboard Operator." \
       org.label-schema.schema-version="1.0" \
       maintainer="Aqua Security Software Ltd." \
-      release=$KUBEBENCH_VERSION \
+      release=v0.15.24 \
       description="Starboard Operator."
 
 RUN microdnf install -y shadow-utils


### PR DESCRIPTION
… to migging labels

## Description

## Related issues
- Close #XXX

Remove this section if you don't have related PRs.

## Checklist
- [ ] I've read the [guidelines for contributing](https://github.com/aquasecurity/starboard/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/starboard/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
