### PR TITLE
Update  python 3.7 -> 3.15 for 'Publish Helm chart' workflow

### DIFF
--- a/.github/workflows/publish-helm-chart.yaml
+++ b/.github/workflows/publish-helm-chart.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@98f2ad02fd48d057ee3b4d4f66525b231c3e52b6
         with:
-          python-version: 3.7
+          python-version: 3.15
       - name: Setup Chart Linting
         id: lint
         uses: helm/chart-testing-action@dae259e86a35ff09145c0805e2d7dd3f7207064a  # v2.1.0


### PR DESCRIPTION
## Description
chore: fix broken workflow "Publish Helm Chart"