### PR TITLE
itest: switch rolling-update target to wordpress:5-fpm-alpine

### DIFF
--- a/itest/helper/helper.go
+++ b/itest/helper/helper.go
@@ -462,7 +462,7 @@ func (h *Helper) UpdateDeploymentImage(namespace, name string) error {
 		}
 
 		dcDeploy := deployment.DeepCopy()
-		dcDeploy.Spec.Template.Spec.Containers[0].Image = "wordpress:5"
+		dcDeploy.Spec.Template.Spec.Containers[0].Image = "wordpress:5-fpm-alpine"
 		err = h.kubeClient.Update(context.TODO(), dcDeploy)
 		if err != nil && errors.IsConflict(err) {
 			return false, nil


### PR DESCRIPTION
The Debian-based wordpress:5 image's Trivy report has grown past etcd's 2 MiB max-request-bytes ceiling, causing the operator's VulnerabilityReport write to fail with gRPC ResourceExhausted on every reconcile. Switching to the Alpine variant keeps the test's intent (rolling update to a different image triggers a new scan) and brings the report comfortably back under the limit.

