### PR TITLE
ci: update workflows and migrate docs dependencies

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -30,12 +30,7 @@ jobs:
         with:
           python-version: 3.x
       - run: |
-          pip install git+https://${GH_TOKEN}@github.com/squidfunk/mkdocs-material-insiders.git
-          pip install mike
-          pip install mkdocs-macros-plugin
-        env:
-          # Note: It is not the same as ${{ secrets.GITHUB_TOKEN }} !
-          GH_TOKEN: ${{ secrets.MKDOCS_AQUA_BOT }}
+          pip install mkdocs-material==9.7.6 mkdocs-macros-plugin mike
       - run: |
           git config user.name "aqua-bot"
           git config user.email "aqua-bot@users.noreply.github.com"

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -16,7 +16,7 @@ permissions: {}
 jobs:
   deploy:
     name: Deploy documentation
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-2404-2core
     permissions:
       contents: write
     steps:

--- a/.github/workflows/release-snapshot.yaml
+++ b/.github/workflows/release-snapshot.yaml
@@ -46,18 +46,18 @@ jobs:
           ignore-unfixed: true
           severity: 'CRITICAL,HIGH'
       - name: Scan Starboard Operator image for vulnerabilities
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 #v0.36.0
         with:
           image-ref: 'docker.io/aquasec/starboard-operator:${{ github.sha }}-amd64'
           exit-code: '1'
           ignore-unfixed: true
           severity: 'CRITICAL,HIGH'
-      - name: Notify dedicated teams channel
-        uses: jdcargile/ms-teams-notification@v1.3
-        if: failure()
-        with:
-          github-token: ${{ secrets.ORG_REPO_TOKEN }}
-          ms-teams-webhook-uri: ${{ secrets.MS_TEAMS_WEBHOOK_URI }}
-          notification-summary: vulnerabilities has been found in starboard-operator image
-          notification-color: 17a2b8
-          timezone: America/Denver
+#      - name: Notify dedicated teams channel
+#        uses: jdcargile/ms-teams-notification@v1.3
+#        if: failure()
+#        with:
+#          github-token: ${{ secrets.ORG_REPO_TOKEN }}
+#          ms-teams-webhook-uri: ${{ secrets.MS_TEAMS_WEBHOOK_URI }}
+#          notification-summary: vulnerabilities has been found in starboard-operator image
+#          notification-color: 17a2b8
+#          timezone: America/Denver

--- a/.github/workflows/release-snapshot.yaml
+++ b/.github/workflows/release-snapshot.yaml
@@ -16,7 +16,7 @@ permissions: {}
 jobs:
   release-snapshot:
     name: Release unversioned snapshot
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-2404-2core
     env:
       DOCKER_CLI_EXPERIMENTAL: "enabled"
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -151,7 +151,7 @@ jobs:
       - itest-starboard
       - itest-starboard-operator
       - integration-operator-conftest
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-2404-2core
     permissions:
       contents: write
     env:


### PR DESCRIPTION
## Description
This PR introduces next updates:
- Switch runners from ubuntu-24.04 to ubuntu-2404-2core in publish-docs, release-snapshot, and release workflows.                                                                                   
- Replace mkdocs-material-insiders (private, token-gated) with the public mkdocs-material==9.7.6.                                                                                                   
- Pin trivy-action to a specific commit hash for reproducibility.                                                                                                                                   
- Disable MS Teams failure notifications  for a while.

## Checklist
- [ ] I've read the [guidelines for contributing](https://github.com/aquasecurity/starboard/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/starboard/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
