### PR TITLE
ci: migrate to Github APP

### DIFF
--- a/.github/workflows/publish-helm-chart.yaml
+++ b/.github/workflows/publish-helm-chart.yaml
@@ -9,63 +9,78 @@ on:
       ref:
         description: The branch, tag or SHA to publish, e.g. v0.0.1
         required: true
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - closed
+    branches:
+      - main
+    paths:
+      - 'deploy/helm/**'
+
 env:
   HELM_REP: helm-charts
   GH_OWNER: aquasecurity
   CHART_DIR: deploy/helm
-  KIND_VERSION: "v0.11.1"
-  KIND_IMAGE: "kindest/node:v1.21.1@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6"
+  KIND_VERSION: "v0.14.0"
+  KIND_IMAGE: "kindest/node:v1.23.6@sha256:b1fa224cc6c7ff32455e0b1fd9cbfd3d3bc87ecaa8fcb06961ed1afb3db0f9ae"
+
 jobs:
-  release:
+  test-chart:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ github.event.inputs.ref }}
           fetch-depth: 0
+          persist-credentials: false
       - name: Install Helm
-        uses: azure/setup-helm@18bc76811624f360dbd7f18c2d4ecb32c7b87bab  # v1.1
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
         with:
-          version: v3.5.0
+          version: v3.14.4
       - name: Set up python
-        uses: actions/setup-python@98f2ad02fd48d057ee3b4d4f66525b231c3e52b6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: 3.7
+          python-version: '3.x'
+          check-latest: true
       - name: Setup Chart Linting
         id: lint
-        uses: helm/chart-testing-action@dae259e86a35ff09145c0805e2d7dd3f7207064a  # v2.1.0
+        uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f # v2.8.0
+        with:
+          # v6.0.0 resolved the compatibility issue with Python > 3.13. may be removed after the action itself is updated
+          yamale_version: "6.0.0"
       - name: Setup Kubernetes cluster (KIND)
-        uses: helm/kind-action@94729529f85113b88f4f819c17ce61382e6d8478  # v1.2.0
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
         with:
           version: ${{ env.KIND_VERSION }}
           image: ${{ env.KIND_IMAGE }}
       - name: Run chart-testing
         run: ct lint-and-install --validate-maintainers=false --charts deploy/helm
-      - name: Install chart-releaser
-        run: |
-          wget https://github.com/helm/chart-releaser/releases/download/v1.3.0/chart-releaser_1.3.0_linux_amd64.tar.gz
-          echo "baed2315a9bb799efb71d512c5198a2a3b8dcd139d7f22f878777cffcd649a37  chart-releaser_1.3.0_linux_amd64.tar.gz" | sha256sum -c -
-          tar xzvf chart-releaser_1.3.0_linux_amd64.tar.gz cr
-      - name: Package helm chart
-        run: |
-          ./cr package ${{ env.CHART_DIR }}
-      - name: Upload helm chart
-        # Failed with upload the same version: https://github.com/helm/chart-releaser/issues/101
-        continue-on-error: true
-        run: |
-          ./cr upload -o ${{ env.GH_OWNER }} -r ${{ env.HELM_REP }} --token ${{ secrets.ORG_REPO_TOKEN }} -p .cr-release-packages
-      - name: Index helm chart
-        run: |
-          ./cr index -o ${{ env.GH_OWNER }} -r ${{ env.HELM_REP }} -c https://${{ env.GH_OWNER }}.github.io/${{ env.HELM_REP }}/ -i index.yaml
-      - name: Push index file
-        uses: dmnemec/copy_file_to_another_repo_action@c93037aa10fa8893de271f19978c980d0c1a9b37  # v1.1.1
-        env:
-          API_TOKEN_GITHUB: ${{ secrets.ORG_REPO_TOKEN }}
+
+  publish-chart:
+    if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
+    needs:
+      - test-chart
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Generate token
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
-          source_file: 'index.yaml'
-          destination_repo: '${{ env.GH_OWNER }}/${{ env.HELM_REP }}'
-          destination_folder: '.'
-          destination_branch: 'gh-pages'
-          user_email: aqua-bot@users.noreply.github.com
-          user_name: 'aqua-bot'
+          client-id: ${{ secrets.HELM_CHARTS_GH_APP_CLIENT_ID }}
+          private-key: ${{ secrets.HELM_CHARTS_GH_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: helm-charts
+      - name: Trigger publish-chart workflow in helm-charts
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REF: ${{ github.event.inputs.ref || github.sha }}
+        run: |
+          gh workflow run publish-chart.yaml \
+            --repo "$GITHUB_REPOSITORY_OWNER/helm-charts" \
+            --ref main \
+            --field "repository=$GITHUB_REPOSITORY" \
+            --field "ref=$REF" \
+            --field "chart_dir=deploy/helm"

--- a/.github/workflows/publish-helm-chart.yaml
+++ b/.github/workflows/publish-helm-chart.yaml
@@ -11,9 +11,6 @@ on:
         required: true
   pull_request:
     types:
-      - opened
-      - synchronize
-      - reopened
       - closed
     branches:
       - main
@@ -21,9 +18,6 @@ on:
       - 'deploy/helm/**'
 
 env:
-  HELM_REP: helm-charts
-  GH_OWNER: aquasecurity
-  CHART_DIR: deploy/helm
   KIND_VERSION: "v0.14.0"
   KIND_IMAGE: "kindest/node:v1.23.6@sha256:b1fa224cc6c7ff32455e0b1fd9cbfd3d3bc87ecaa8fcb06961ed1afb3db0f9ae"
 

--- a/.github/workflows/publish-helm-chart.yaml
+++ b/.github/workflows/publish-helm-chart.yaml
@@ -11,6 +11,9 @@ on:
         required: true
   pull_request:
     types:
+      - opened # to run tests when a PR is created
+      - synchronize # to run tests when a PR is updated with new commits
+      - reopened # to run tests when a PR is reopened after being closed
       - closed
     branches:
       - main


### PR DESCRIPTION
## Description
Replace the personal access token (`ORG_REPO_TOKEN`) with a GitHub App token (via `actions/create-github-app-token`) to trigger the publish workflow in `aquasecurity/helm-charts`.

## Checklist
- [ ] I've read the [guidelines for contributing](https://github.com/aquasecurity/starboard/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/starboard/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
