### PR TITLE
ci: fix release-snapshot workflow failures

### DIFF
--- a/.github/workflows/release-snapshot.yaml
+++ b/.github/workflows/release-snapshot.yaml
@@ -38,8 +38,10 @@ jobs:
         with:
           version: v1.7.0
           args: release --snapshot --skip-publish --rm-dist --timeout 90m
+        env:
+          AQUSEC_ACR_REGISTRY_NAME: aquasecurity
       - name: Scan Starboard CLI image for vulnerabilities
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 #v0.36.0
         with:
           image-ref: 'docker.io/aquasec/starboard:${{ github.sha }}-amd64'
           exit-code: '1'


### PR DESCRIPTION
## Description

This PR fixes the nightly release-snapshot workflow that was failing due missing `AQUSEC_ACR_REGISTRY_NAME` env var — GoReleaser evaluates all image_templates before respecting `--skip-publish`, causing a template rendering error. A hardcoded placeholder value `aquasecurity` is used instead of the real secret since snapshot builds never push to ACR.

Also it fixes unpinned `trivy-action@master` — the first Trivy scan step referenced a mutable branch while the second was already pinned to a SHA. Both steps are now pinned to the same commit (ed142fd, v0.36.0).

## Checklist
- [ ] I've read the [guidelines for contributing](https://github.com/aquasecurity/starboard/blob/main/CONTRIBUTING.md) to this repository.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/starboard/tree/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
